### PR TITLE
Custom serialization (`request_transform`) and deserialization(`response_transform`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Another inspiration is to create a unified Rest Client library that works across
 - [ ] Throw exception when missing key params
 - [X] Add a new class decorator and supports default custom properties and baseUrl at a class / repo level
 - [X] Document usages for the new Decorators
-- [ ] Document steps for custom serialization and deserialization
+- [X] Document steps for custom serialization (`request_transform`) and deserialization(`response_transform`)
 - [X] Deploy to npm modules instead of using github
 - [X] Support to instantiate multiple classes, useful when we need to support Api with different tokens.
 - [X] Support for authorization (Bearer token at the monent)
@@ -230,6 +230,90 @@ doSimpleHttpBinPathParamsGet(
 doSimpleHttpBinPost(@RequestBody _body): any {}
 ```
 
+
+##### Simple request transform
+This example will transform the request before sending the request to the backend. The example
+will do some translation to the input data before sending the data to the backend.
+
+
+```
+import { RestClient, RestApi, RequestBody, PathParam, QueryParams } from '../index';
+
+interface NumberPair {
+  a: number;
+  b: number;
+}
+
+@RestClient({
+  baseUrl: 'https://httpbin.org',
+})
+export class TransformationApiDataStore {
+  @RestApi('/anything', {
+    method: 'POST',
+    request_transform: (fetchOptions: Request, pair: NumberPair): Promise<Request> => {
+      const newBody = {
+        a: pair.a * 100,
+        b: pair.b * 200,
+      };
+
+      return Promise.resolve(
+        Object.assign(fetchOptions, {
+          body: JSON.stringify(newBody),
+        }),
+      );
+    },
+  })
+  doSimpleRequestTransformApi(@RequestBody requestBody: NumberPair): any {}
+}
+
+const myTransformationApiDataStoreInstance = new TransformationApiDataStore();
+const apiResponse = <ApiResponse>(
+  myTransformationApiDataStoreInstance.doSimpleRequestTransformApi({ a: 1, b: 2 })
+);
+
+//... follow the above example to get the data from result promise
+```
+
+
+
+##### Simple response transform
+This example will transform the response before returning the final result to the front end. The
+example code will add the response values and return the sum as the response
+
+
+```
+import { RestClient, RestApi, RequestBody, PathParam, QueryParams } from '../index';
+
+interface NumberPair {
+  a: number;
+  b: number;
+}
+
+@RestClient({
+  baseUrl: 'https://httpbin.org',
+})
+export class TransformationApiDataStore {
+  @RestApi('/anything', {
+    method: 'POST',
+    response_transform: (fetchOptions: Request, resp: Response): Promise<any> => {
+      return resp.json().then((respJson) => {
+        const pair = <NumberPair>JSON.parse(respJson.data);
+        const sum = pair.a + pair.b;
+
+        return { sum };
+      });
+    },
+  })
+  doSimpleResponseTransformApi(@RequestBody requestBody: NumberPair): any {}
+}
+
+const myTransformationApiDataStoreInstance = new TransformationApiDataStore();
+const apiResponse = <ApiResponse>(
+  myTransformationApiDataStoreInstance.doSimpleResponseTransformApi({ a: 300, b: 700 })
+);
+
+//... follow the above example to get the data from result promise
+```
 
 #### Notes
 - For post method and post JSON body of `appplication/json`, the request will stringify and properly saves it into the body

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can also checkout the sample repo that has typescript and other things setup
 #### Install it
 install from npm
 ```
-npm i --save restapi-typescript-decorators@^2.1.1
+npm i --save restapi-typescript-decorators@^2.1.2
 ```
 
 Make sure you have the typescript and decorator enabled in your `tsconfig.json`
@@ -231,9 +231,11 @@ doSimpleHttpBinPost(@RequestBody _body): any {}
 ```
 
 
+#### Transformations
+You can use `request_transform` and `response_transform` to do transformation on the request and response API
+
 ##### Simple request transform
-This example will transform the request before sending the request to the backend. The example
-will do some translation to the input data before sending the data to the backend.
+This example will transform the request before sending the request to the backend. The example will do some translation to the input data before sending the data to the backend.
 
 
 ```
@@ -277,8 +279,7 @@ const apiResponse = <ApiResponse>(
 
 
 ##### Simple response transform
-This example will transform the response before returning the final result to the front end. The
-example code will add the response values and return the sum as the response
+This example will transform the response before returning the final result to the front end. The example code will add the response values and return the sum as the response
 
 
 ```
@@ -324,7 +325,7 @@ Create PR against master.
 
 #### Note on release pipeline
 ```
-npm run build && \
 npm version patch && \
+npm run build && \
 npm publish
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "restapi-typescript-decorators",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restapi-typescript-decorators",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Decorators that helps reduce the boilderplate code for rest api calls on the frontend and node js",
   "main": "build/index",
   "scripts": {

--- a/src/__tests__/TransformationApiDataStore.spec.ts
+++ b/src/__tests__/TransformationApiDataStore.spec.ts
@@ -1,0 +1,29 @@
+import { ApiResponse } from '../index';
+import { TransformationApiDataStore } from './TransformationApiDataStore';
+
+const myTransformationApiDataStoreInstance = new TransformationApiDataStore();
+
+test('Simple Request Transformation API should work - transform before request is sent', () => {
+  const apiResponse = <ApiResponse>(
+    myTransformationApiDataStoreInstance.doSimpleRequestTransformApi({a: 1, b: 2})
+  );
+
+  return apiResponse.result.then((resp) => {
+    expect(apiResponse.ok).toBe(true);
+    expect(apiResponse.status).toEqual(200);
+    expect(resp.json).toEqual('');
+  });
+});
+
+
+test('Simple Request Transformation API should work - transform before response is returned', () => {
+  const apiResponse = <ApiResponse>(
+    myTransformationApiDataStoreInstance.doSimpleResponseTransformApi({ a: 1, b: 2 })
+  );
+
+  return apiResponse.result.then((resp) => {
+    expect(apiResponse.ok).toBe(true);
+    expect(apiResponse.status).toEqual(200);
+    expect(resp.json).toEqual('');
+  });
+});

--- a/src/__tests__/TransformationApiDataStore.spec.ts
+++ b/src/__tests__/TransformationApiDataStore.spec.ts
@@ -5,25 +5,25 @@ const myTransformationApiDataStoreInstance = new TransformationApiDataStore();
 
 test('Simple Request Transformation API should work - transform before request is sent', () => {
   const apiResponse = <ApiResponse>(
-    myTransformationApiDataStoreInstance.doSimpleRequestTransformApi({a: 1, b: 2})
+    myTransformationApiDataStoreInstance.doSimpleRequestTransformApi({ a: 1, b: 2 })
   );
 
   return apiResponse.result.then((resp) => {
     expect(apiResponse.ok).toBe(true);
     expect(apiResponse.status).toEqual(200);
-    expect(resp.json).toEqual('');
+    expect(apiResponse.request_body).toEqual('{"a":100,"b":400}');
+    expect(resp.json).toEqual({ a: 100, b: 400 });
   });
 });
 
-
 test('Simple Request Transformation API should work - transform before response is returned', () => {
   const apiResponse = <ApiResponse>(
-    myTransformationApiDataStoreInstance.doSimpleResponseTransformApi({ a: 1, b: 2 })
+    myTransformationApiDataStoreInstance.doSimpleResponseTransformApi({ a: 300, b: 700 })
   );
 
   return apiResponse.result.then((resp) => {
     expect(apiResponse.ok).toBe(true);
     expect(apiResponse.status).toEqual(200);
-    expect(resp.json).toEqual('');
+    expect(resp).toEqual({ sum: 1000 });
   });
 });

--- a/src/__tests__/TransformationApiDataStore.ts
+++ b/src/__tests__/TransformationApiDataStore.ts
@@ -1,16 +1,46 @@
 import { RestClient, RestApi, RequestBody, PathParam, QueryParams } from '../index';
 
+interface NumberPair {
+  a: number;
+  b: number;
+}
+
 @RestClient({
   baseUrl: 'https://httpbin.org',
 })
 export class TransformationApiDataStore {
+  // this example will transform the request to make a and b and multiply
+  // them by 100 and 200 respectively before sending them to the back end
   @RestApi('/anything', {
     method: 'POST',
-  })
-  doSimpleRequestTransformApi(@RequestBody requestBody: object): any {}
+    request_transform: (fetchOptions: Request, pair: NumberPair): Promise<Request> => {
+      const newBody = {
+        a: pair.a * 100,
+        b: pair.b * 200,
+      };
 
+      return Promise.resolve(
+        Object.assign(fetchOptions, {
+          body: JSON.stringify(newBody),
+        }),
+      );
+    },
+  })
+  doSimpleRequestTransformApi(@RequestBody requestBody: NumberPair): any {}
+
+  // this example will make the api response to the backend
+  // then transform the returned data by adding the 2 numbers a and b
+  // and return the result as a sum
   @RestApi('/anything', {
     method: 'POST',
+    response_transform: (fetchOptions: Request, resp: Response): Promise<any> => {
+      return resp.json().then((respJson) => {
+        const pair = <NumberPair>JSON.parse(respJson.data);
+        const sum = pair.a + pair.b;
+
+        return { sum };
+      });
+    },
   })
-  doSimpleResponseTransformApi(@RequestBody requestBody: object): any {}
+  doSimpleResponseTransformApi(@RequestBody requestBody: NumberPair): any {}
 }

--- a/src/__tests__/TransformationApiDataStore.ts
+++ b/src/__tests__/TransformationApiDataStore.ts
@@ -1,0 +1,16 @@
+import { RestClient, RestApi, RequestBody, PathParam, QueryParams } from '../index';
+
+@RestClient({
+  baseUrl: 'https://httpbin.org',
+})
+export class TransformationApiDataStore {
+  @RestApi('/anything', {
+    method: 'POST',
+  })
+  doSimpleRequestTransformApi(@RequestBody requestBody: object): any {}
+
+  @RestApi('/anything', {
+    method: 'POST',
+  })
+  doSimpleResponseTransformApi(@RequestBody requestBody: object): any {}
+}


### PR DESCRIPTION
Changed `request_transform` and `response_transform` to return a promise (would be useful to handle async in the request and response)

[X] Document steps for custom serialization (`request_transform`) and deserialization(`response_transform`)
