### PR TITLE
Minor Type Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Another inspiration is to create a unified Rest Client library that works across
 - [X] Make CI pipeline publish to npm registry
 - [X] Uses `ApiResponse` for return type instead of `any`
 - [X] Consolidate enum / string types for `HttpVerb` and `AuthType`
-- [X] Support Serialization into an Object of custom types
+- [X] Support Serialization of Response Object into custom type
 - [ ] Throw exception when missing key params
 - [ ] Add API retry actions
 - [ ] Add API debounce actions

--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ Another inspiration is to create a unified Rest Client library that works across
 - [X] Make CI pipeline publish to npm registry
 - [X] Uses `ApiResponse` for return type instead of `any`
 - [X] Consolidate enum / string types for `HttpVerb` and `AuthType`
+- [X] Support Serialization into an Object of custom types
 - [ ] Throw exception when missing key params
 - [ ] Add API retry actions
 - [ ] Add API debounce actions
-- [ ] Support Serialization into an Object of custom types
+
 
 ### How to use
 You can also checkout the sample repo that has typescript and other things setup at https://github.com/synle/restapi-typescript-decorators-example
@@ -77,16 +78,16 @@ export class PublicApiDataStore {
   @RestApi('/post', {
     method: 'POST',
   })
-  doSimpleHttpBinPost(@RequestBody _body): ApiResponse {}
+  doSimpleHttpBinPost(@RequestBody _body): ApiResponse<any> {}
 
   @RestApi('/get')
-  doSimpleHttpBinGet(@QueryParams _queryParams): ApiResponse {}
+  doSimpleHttpBinGet(@QueryParams _queryParams): ApiResponse<any> {}
 
   @RestApi('/anything/{messageId}')
   doSimpleHttpBinPathParamsGet(
     @PathParam('messageId') _targetMessageId,
     @QueryParams _queryParams,
-  ): ApiResponse {}
+  ): ApiResponse<any> {}
 }
 ```
 
@@ -125,7 +126,7 @@ export class PrivateBearerAuthApiDataStore {
   @RestApi('/bearer', {
     method: 'GET',
   })
-  doApiCallWithBearerToken(): ApiResponse {}
+  doApiCallWithBearerToken(): ApiResponse<any> {}
 }
 ```
 
@@ -168,7 +169,7 @@ export class PrivateBasicAuthApiDataStore {
   @RestApi('/basic-auth/good_username/good_password', {
     method: 'GET',
   })
-  doApiCallWithBasicUsernameAndPassword(): ApiResponse {}
+  doApiCallWithBasicUsernameAndPassword(): ApiResponse<any> {}
 }
 ```
 
@@ -217,7 +218,7 @@ if(apiResponse){
 ##### Simple Get Rest Calls with Query String
 ```
 @RestApi("/get")
-doSimpleHttpBinGet(@QueryParams _queryParams): ApiResponse {}
+doSimpleHttpBinGet(@QueryParams _queryParams): ApiResponse<any> {}
 ```
 
 ##### Simple Get Rest Calls with Path Param
@@ -225,7 +226,7 @@ doSimpleHttpBinGet(@QueryParams _queryParams): ApiResponse {}
 @RestApi("/anything/{messageId}")
 doSimpleHttpBinPathParamsGet(
   @PathParam("messageId") _targetMessageId: string
-): ApiResponse {}
+): ApiResponse<any> {}
 ```
 
 ##### Simple Get Rest Calls with Path Param and Query String
@@ -234,7 +235,7 @@ doSimpleHttpBinPathParamsGet(
 doSimpleHttpBinPathParamsGet(
   @PathParam("messageId") _targetMessageId : string,
   @QueryParams _queryParams
-): ApiResponse {}
+): ApiResponse<any> {}
 ```
 
 ##### Simple Post Rest Calls
@@ -242,7 +243,39 @@ doSimpleHttpBinPathParamsGet(
 @RestApi("/post", {
   method: "POST",
 })
-doSimpleHttpBinPost(@RequestBody _body): ApiResponse {}
+doSimpleHttpBinPost(@RequestBody _body): ApiResponse<any> {}
+```
+
+#### Type casting your response type
+Sometimes it might be useful to cast / parsing the json object in the response to match certain object type. We can do so with this library using this approach.
+
+First define a custom interface
+```
+// interface for request
+interface NumberPair {
+  a: number;
+  b: number;
+}
+
+// interface for response
+interface CollectionSum {
+  sum: number;
+}
+```
+
+Then RestClient class will look something like this
+```
+import { RestClient, RestApi, RequestBody, PathParam, QueryParams, ApiResponse } from 'restapi-typescript-decorators';
+
+@RestClient({
+  baseUrl: 'https://httpbin.org',
+})
+export class TransformationApiDataStore {
+  @RestApi('/calculateSum', {
+    method: 'POST',
+  })
+  doSimpleResponseTransformApi(@RequestBody requestBody: NumberPair): ApiResponse<CollectionSum> {}
+}
 ```
 
 
@@ -280,7 +313,7 @@ export class TransformationApiDataStore {
       );
     },
   })
-  doSimpleRequestTransformApi(@RequestBody requestBody: NumberPair): ApiResponse {}
+  doSimpleRequestTransformApi(@RequestBody requestBody: NumberPair): ApiResponse<any> {}
 }
 
 const myTransformationApiDataStoreInstance = new TransformationApiDataStore();
@@ -320,7 +353,7 @@ export class TransformationApiDataStore {
       });
     },
   })
-  doSimpleResponseTransformApi(@RequestBody requestBody: NumberPair): ApiResponse {}
+  doSimpleResponseTransformApi(@RequestBody requestBody: NumberPair): ApiResponse<any> {}
 }
 
 const myTransformationApiDataStoreInstance = new TransformationApiDataStore();

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Another inspiration is to create a unified Rest Client library that works across
 - [ ] Throw exception when missing key params
 - [ ] Add API retry actions
 - [ ] Add API debounce actions
+- [ ] Support Serialization into an Object of custom types
 
 ### How to use
 You can also checkout the sample repo that has typescript and other things setup at https://github.com/synle/restapi-typescript-decorators-example
@@ -37,7 +38,7 @@ You can also checkout the sample repo that has typescript and other things setup
 #### Install it
 install from npm
 ```
-npm i --save restapi-typescript-decorators@^2
+npm i --save restapi-typescript-decorators@^3
 ```
 
 Make sure you have the typescript and decorator enabled in your `tsconfig.json`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "restapi-typescript-decorators",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "restapi-typescript-decorators",
-  "version": "2.1.12",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restapi-typescript-decorators",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Decorators that helps reduce the boilderplate code for rest api calls on the frontend and node js",
   "main": "build/index",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "restapi-typescript-decorators",
-  "version": "2.1.12",
+  "version": "3.0.0",
   "description": "Decorators that helps reduce the boilderplate code for rest api calls on the frontend and node js",
   "main": "build/index",
   "scripts": {
     "build": "npx jest --clearCache && rm -rf build/* && ./node_modules/.bin/tsc",
     "format": "./node_modules/.bin/prettier --config ./.prettierrc --write src/**/**/**/**/*.{ts,tsx,js,jsx,scss} *.{json,MD}",
+    "clean": "npx jest --clearCache && rm -rf build/*",
     "test": "npx jest --ci"
   },
   "repository": {

--- a/src/__tests__/HttpBinTypes.ts
+++ b/src/__tests__/HttpBinTypes.ts
@@ -1,0 +1,17 @@
+export interface HttpBinAuthResponse {
+  authenticated: boolean;
+  user?: string;
+  token?: string;
+}
+
+export interface HttpBinGetResponse {
+  args?: object;
+  headers?: object;
+  origin?: string;
+  url?: string;
+  data?: object;
+  json?: string;
+  form?: object;
+}
+
+export interface HttpBinPostResponse extends HttpBinGetResponse {}

--- a/src/__tests__/PrivateBasicAuthApiDataStore.spec.ts
+++ b/src/__tests__/PrivateBasicAuthApiDataStore.spec.ts
@@ -1,28 +1,36 @@
-import { ApiResponse } from '../index';
 import { PrivateBasicAuthApiDataStore } from './PrivateBasicAuthApiDataStore';
 
 const validDataStore = new PrivateBasicAuthApiDataStore('good_username', 'good_password');
 const invalidDataStore = new PrivateBasicAuthApiDataStore('bogus_u1', 'bogus_pwd1');
 
 test('Simple Basic Auth Private Authenticated API Should work with good credentials', () => {
-  const apiResponse = <ApiResponse>validDataStore.doApiCallWithBasicUsernameAndPassword();
+  const apiResponse = validDataStore.doApiCallWithBasicUsernameAndPassword();
 
-  return apiResponse.result.then((resp) => {
-    expect(apiResponse.url).toBe('https://httpbin.org/basic-auth/good_username/good_password');
-    expect(apiResponse.ok).toBe(true);
-    expect(apiResponse.status).toBe(200);
-    expect(resp.authenticated).toBe(true);
-    expect(resp.user).toEqual('good_username');
-  });
+  expect(apiResponse).toBeDefined();
+
+  if (apiResponse) {
+    return apiResponse.result.then((resp) => {
+      expect(apiResponse.url).toBe('https://httpbin.org/basic-auth/good_username/good_password');
+      expect(apiResponse.ok).toBe(true);
+      expect(apiResponse.status).toBe(200);
+      expect(resp.authenticated).toBe(true);
+      expect(resp.user).toEqual('good_username');
+    });
+  }
 });
 
 test('Simple Basic Auth Private Authenticated API Should fail with bad credentials', () => {
-  const apiResponse = <ApiResponse>invalidDataStore.doApiCallWithBasicUsernameAndPassword();
-  return apiResponse.result.then((resp) => {
-    expect(apiResponse.url).toBe('https://httpbin.org/basic-auth/good_username/good_password');
-    expect(apiResponse.ok).toBe(false);
-    expect(apiResponse.status).toBe(401);
-    expect(apiResponse.statusText).toBe('UNAUTHORIZED');
-    expect(resp).toBe('');
-  });
+  const apiResponse = invalidDataStore.doApiCallWithBasicUsernameAndPassword();
+
+  expect(apiResponse).toBeDefined();
+
+  if (apiResponse) {
+    return apiResponse.result.then((resp) => {
+      expect(apiResponse.url).toBe('https://httpbin.org/basic-auth/good_username/good_password');
+      expect(apiResponse.ok).toBe(false);
+      expect(apiResponse.status).toBe(401);
+      expect(apiResponse.statusText).toBe('UNAUTHORIZED');
+      expect(resp).toBe('');
+    });
+  }
 });

--- a/src/__tests__/PrivateBasicAuthApiDataStore.ts
+++ b/src/__tests__/PrivateBasicAuthApiDataStore.ts
@@ -27,5 +27,5 @@ export class PrivateBasicAuthApiDataStore {
   @RestApi('/basic-auth/good_username/good_password', {
     method: 'GET',
   })
-  doApiCallWithBasicUsernameAndPassword(): any {}
+  doApiCallWithBasicUsernameAndPassword(): ApiResponse {}
 }

--- a/src/__tests__/PrivateBasicAuthApiDataStore.ts
+++ b/src/__tests__/PrivateBasicAuthApiDataStore.ts
@@ -8,6 +8,8 @@ import {
   ApiResponse,
 } from '../index';
 
+import { HttpBinAuthResponse } from './HttpBinTypes';
+
 @RestClient({
   baseUrl: 'https://httpbin.org',
   authType: 'Basic',
@@ -27,5 +29,5 @@ export class PrivateBasicAuthApiDataStore {
   @RestApi('/basic-auth/good_username/good_password', {
     method: 'GET',
   })
-  doApiCallWithBasicUsernameAndPassword(): ApiResponse {}
+  doApiCallWithBasicUsernameAndPassword(): ApiResponse<HttpBinAuthResponse> {}
 }

--- a/src/__tests__/PrivateBearerAuthApiDataStore.spec.ts
+++ b/src/__tests__/PrivateBearerAuthApiDataStore.spec.ts
@@ -1,4 +1,3 @@
-import { ApiResponse } from '../index';
 import { PrivateBearerAuthApiDataStore } from './PrivateBearerAuthApiDataStore';
 
 const testAccessToken = '<<some_strong_and_random_access_token>>';
@@ -7,24 +6,33 @@ const invalidDataStore = new PrivateBearerAuthApiDataStore('');
 const validDataStore = new PrivateBearerAuthApiDataStore(testAccessToken);
 
 test('Simple Private Authenticated API Should work with correct access token', () => {
-  const apiResponse = <ApiResponse>validDataStore.doApiCallWithBearerToken();
+  const apiResponse = validDataStore.doApiCallWithBearerToken();
 
-  return apiResponse.result.then((resp) => {
-    expect(apiResponse.url).toBe('https://httpbin.org/bearer');
-    expect(apiResponse.ok).toBe(true);
-    expect(apiResponse.status).toBe(200);
-    expect(resp.authenticated).toBe(true);
-    expect(resp.token).toEqual(testAccessToken);
-  });
+  expect(apiResponse).toBeDefined();
+
+  if (apiResponse) {
+    return apiResponse.result.then((resp) => {
+      expect(apiResponse.url).toBe('https://httpbin.org/bearer');
+      expect(apiResponse.ok).toBe(true);
+      expect(apiResponse.status).toBe(200);
+      expect(resp.authenticated).toBe(true);
+      expect(resp.token).toEqual(testAccessToken);
+    });
+  }
 });
 
 test('Simple Private Authenticated API Should fail with no access token', () => {
-  const apiResponse = <ApiResponse>invalidDataStore.doApiCallWithBearerToken();
-  return apiResponse.result.then((resp) => {
-    expect(apiResponse.url).toBe('https://httpbin.org/bearer');
-    expect(apiResponse.ok).toBe(false);
-    expect(apiResponse.status).toBe(401);
-    expect(apiResponse.statusText).toBe('UNAUTHORIZED');
-    expect(resp).toBe('');
-  });
+  const apiResponse = invalidDataStore.doApiCallWithBearerToken();
+
+  expect(apiResponse).toBeDefined();
+
+  if (apiResponse) {
+    return apiResponse.result.then((resp) => {
+      expect(apiResponse.url).toBe('https://httpbin.org/bearer');
+      expect(apiResponse.ok).toBe(false);
+      expect(apiResponse.status).toBe(401);
+      expect(apiResponse.statusText).toBe('UNAUTHORIZED');
+      expect(resp).toBe('');
+    });
+  }
 });

--- a/src/__tests__/PrivateBearerAuthApiDataStore.ts
+++ b/src/__tests__/PrivateBearerAuthApiDataStore.ts
@@ -23,5 +23,5 @@ export class PrivateBearerAuthApiDataStore {
   @RestApi('/bearer', {
     method: 'GET',
   })
-  doApiCallWithBearerToken(): any {}
+  doApiCallWithBearerToken(): ApiResponse {}
 }

--- a/src/__tests__/PrivateBearerAuthApiDataStore.ts
+++ b/src/__tests__/PrivateBearerAuthApiDataStore.ts
@@ -8,6 +8,8 @@ import {
   ApiResponse,
 } from '../index';
 
+import { HttpBinAuthResponse } from './HttpBinTypes';
+
 @RestClient({
   baseUrl: 'https://httpbin.org',
   authType: 'Bearer',
@@ -23,5 +25,5 @@ export class PrivateBearerAuthApiDataStore {
   @RestApi('/bearer', {
     method: 'GET',
   })
-  doApiCallWithBearerToken(): ApiResponse {}
+  doApiCallWithBearerToken(): ApiResponse<HttpBinAuthResponse> {}
 }

--- a/src/__tests__/PublicApiDataStore.spec.ts
+++ b/src/__tests__/PublicApiDataStore.spec.ts
@@ -1,34 +1,39 @@
-import { ApiResponse } from '../index';
 import { PublicApiDataStore } from './PublicApiDataStore';
 
 const unAuthDataStoreInstance = new PublicApiDataStore();
 
 test('Simple Public HTTP POST should work', () => {
-  const apiResponse = <ApiResponse>(
-    unAuthDataStoreInstance.doSimpleHttpBinPost({ a: 1, b: 2, c: 3 })
-  );
+  const apiResponse = unAuthDataStoreInstance.doSimpleHttpBinPost({ a: 1, b: 2, c: 3 });
 
-  return apiResponse.result.then((resp) => {
-    expect(apiResponse.ok).toBe(true);
-    expect(apiResponse.status).toEqual(200);
-    expect(resp.json).toEqual({ a: 1, b: 2, c: 3 });
-    expect(resp.url).toEqual('https://httpbin.org/post');
-  });
+  expect(apiResponse).toBeDefined();
+
+  if (apiResponse) {
+    return apiResponse.result.then((resp) => {
+      expect(apiResponse.ok).toBe(true);
+      expect(apiResponse.status).toEqual(200);
+      expect(resp.json).toEqual({ a: 1, b: 2, c: 3 });
+      expect(resp.url).toEqual('https://httpbin.org/post');
+    });
+  }
 });
 
 test('Simple Public HTTP GET with query params should work', () => {
-  const apiResponse = <ApiResponse>unAuthDataStoreInstance.doSimpleHttpBinGet({ a: 1, b: 2, c: 3 });
+  const apiResponse = unAuthDataStoreInstance.doSimpleHttpBinGet({ a: 1, b: 2, c: 3 });
 
-  return apiResponse.result.then((resp) => {
-    expect(apiResponse.ok).toBe(true);
-    expect(apiResponse.status).toEqual(200);
-    expect(resp.args).toEqual({ a: '1', b: '2', c: '3' });
-    expect(resp.url).toEqual('https://httpbin.org/get?a=1&b=2&c=3');
-  });
+  expect(apiResponse).toBeDefined();
+
+  if (apiResponse) {
+    return apiResponse.result.then((resp) => {
+      expect(apiResponse.ok).toBe(true);
+      expect(apiResponse.status).toEqual(200);
+      expect(resp.args).toEqual({ a: '1', b: '2', c: '3' });
+      expect(resp.url).toEqual('https://httpbin.org/get?a=1&b=2&c=3');
+    });
+  }
 });
 
 test('Simple Public HTTP GET with path params and query params should work', () => {
-  const apiResponse = <ApiResponse>unAuthDataStoreInstance.doSimpleHttpBinPathParamsGet(
+  const apiResponse = unAuthDataStoreInstance.doSimpleHttpBinPathParamsGet(
     'secret_message_id_123',
     {
       aa: 1,
@@ -37,10 +42,14 @@ test('Simple Public HTTP GET with path params and query params should work', () 
     },
   );
 
-  return apiResponse.result.then((resp) => {
-    expect(apiResponse.ok).toBe(true);
-    expect(apiResponse.status).toEqual(200);
-    expect(resp.args).toEqual({ aa: '1', bb: '2', cc: '3' });
-    expect(resp.url).toEqual('https://httpbin.org/anything/secret_message_id_123?aa=1&bb=2&cc=3');
-  });
+  expect(apiResponse).toBeDefined();
+
+  if (apiResponse) {
+    return apiResponse.result.then((resp) => {
+      expect(apiResponse.ok).toBe(true);
+      expect(apiResponse.status).toEqual(200);
+      expect(resp.args).toEqual({ aa: '1', bb: '2', cc: '3' });
+      expect(resp.url).toEqual('https://httpbin.org/anything/secret_message_id_123?aa=1&bb=2&cc=3');
+    });
+  }
 });

--- a/src/__tests__/PublicApiDataStore.ts
+++ b/src/__tests__/PublicApiDataStore.ts
@@ -1,4 +1,4 @@
-import { RestClient, RestApi, RequestBody, PathParam, QueryParams } from '../index';
+import { RestClient, RestApi, RequestBody, PathParam, QueryParams, ApiResponse } from '../index';
 
 @RestClient({
   baseUrl: 'https://httpbin.org',
@@ -7,14 +7,14 @@ export class PublicApiDataStore {
   @RestApi('/post', {
     method: 'POST',
   })
-  doSimpleHttpBinPost(@RequestBody _body): any {}
+  doSimpleHttpBinPost(@RequestBody _body): ApiResponse {}
 
   @RestApi('/get')
-  doSimpleHttpBinGet(@QueryParams _queryParams): any {}
+  doSimpleHttpBinGet(@QueryParams _queryParams): ApiResponse {}
 
   @RestApi('/anything/{messageId}')
   doSimpleHttpBinPathParamsGet(
     @PathParam('messageId') _targetMessageId: string,
     @QueryParams _queryParams,
-  ): any {}
+  ): ApiResponse {}
 }

--- a/src/__tests__/PublicApiDataStore.ts
+++ b/src/__tests__/PublicApiDataStore.ts
@@ -1,5 +1,7 @@
 import { RestClient, RestApi, RequestBody, PathParam, QueryParams, ApiResponse } from '../index';
 
+import { HttpBinGetResponse, HttpBinPostResponse } from './HttpBinTypes';
+
 @RestClient({
   baseUrl: 'https://httpbin.org',
 })
@@ -7,14 +9,14 @@ export class PublicApiDataStore {
   @RestApi('/post', {
     method: 'POST',
   })
-  doSimpleHttpBinPost(@RequestBody _body): ApiResponse {}
+  doSimpleHttpBinPost(@RequestBody _body): ApiResponse<HttpBinPostResponse> {}
 
   @RestApi('/get')
-  doSimpleHttpBinGet(@QueryParams _queryParams): ApiResponse {}
+  doSimpleHttpBinGet(@QueryParams _queryParams): ApiResponse<HttpBinGetResponse> {}
 
   @RestApi('/anything/{messageId}')
   doSimpleHttpBinPathParamsGet(
     @PathParam('messageId') _targetMessageId: string,
     @QueryParams _queryParams,
-  ): ApiResponse {}
+  ): ApiResponse<HttpBinGetResponse> {}
 }

--- a/src/__tests__/TransformationApiDataStore.spec.ts
+++ b/src/__tests__/TransformationApiDataStore.spec.ts
@@ -1,46 +1,57 @@
-import { ApiResponse } from '../index';
 import { TransformationApiDataStore } from './TransformationApiDataStore';
 
 const myTransformationApiDataStoreInstance = new TransformationApiDataStore();
 
 test('Simple Request Transformation API should work - transform before request is sent', () => {
-  const apiResponse = <ApiResponse>(
-    myTransformationApiDataStoreInstance.doSimpleRequestTransformApi({ a: 1, b: 2 })
-  );
-
-  return apiResponse.result.then((resp) => {
-    expect(apiResponse.ok).toBe(true);
-    expect(apiResponse.status).toEqual(200);
-    expect(apiResponse.request_body).toEqual('{"a":100,"b":400}');
-    expect(resp.json).toEqual({ a: 100, b: 400 });
+  const apiResponse = myTransformationApiDataStoreInstance.doSimpleRequestTransformApi({
+    a: 1,
+    b: 2,
   });
+
+  expect(apiResponse).toBeDefined();
+
+  if (apiResponse) {
+    return apiResponse.result.then((resp) => {
+      expect(apiResponse.ok).toBe(true);
+      expect(apiResponse.status).toEqual(200);
+      expect(apiResponse.request_body).toEqual('{"a":100,"b":400}');
+      expect(resp.json).toEqual({ a: 100, b: 400 });
+    });
+  }
 });
 
 test('Simple Request Transformation API should work - transform before response is returned', () => {
-  const apiResponse = <ApiResponse>(
-    myTransformationApiDataStoreInstance.doSimpleResponseTransformApi({ a: 300, b: 700 })
-  );
-
-  return apiResponse.result.then((resp) => {
-    expect(apiResponse.ok).toBe(true);
-    expect(apiResponse.status).toEqual(200);
-    expect(resp).toEqual({ sum: 1000 });
+  const apiResponse = myTransformationApiDataStoreInstance.doSimpleResponseTransformApi({
+    a: 300,
+    b: 700,
   });
+
+  expect(apiResponse).toBeDefined();
+
+  if (apiResponse) {
+    return apiResponse.result.then((resp) => {
+      expect(apiResponse.ok).toBe(true);
+      expect(apiResponse.status).toEqual(200);
+      expect(resp).toEqual({ sum: 1000 });
+    });
+  }
 });
 
 test('Simple Request Transformation API should work - complex API transform before response is returned', () => {
-  const apiResponse = <ApiResponse>(
-    myTransformationApiDataStoreInstance.doComplexRequestTransformation({
-      a: 100,
-      b: 200,
-      c: 300,
-      d: 400,
-    })
-  );
-
-  return apiResponse.result.then((resp) => {
-    expect(apiResponse.ok).toBe(true);
-    expect(apiResponse.status).toEqual(200);
-    expect(resp.json).toEqual({ totalAmount: 1000, sum1: 300, sum2: 700 });
+  const apiResponse = myTransformationApiDataStoreInstance.doComplexRequestTransformation({
+    a: 100,
+    b: 200,
+    c: 300,
+    d: 400,
   });
+
+  expect(apiResponse).toBeDefined();
+
+  if (apiResponse) {
+    return apiResponse.result.then((resp) => {
+      expect(apiResponse.ok).toBe(true);
+      expect(apiResponse.status).toEqual(200);
+      expect(resp.json).toEqual({ totalAmount: 1000, sum1: 300, sum2: 700 });
+    });
+  }
 });

--- a/src/__tests__/TransformationApiDataStore.spec.ts
+++ b/src/__tests__/TransformationApiDataStore.spec.ts
@@ -51,7 +51,7 @@ test('Simple Request Transformation API should work - complex API transform befo
     return apiResponse.result.then((resp) => {
       expect(apiResponse.ok).toBe(true);
       expect(apiResponse.status).toEqual(200);
-      expect(resp.json).toEqual({ totalAmount: 1000, sum1: 300, sum2: 700 });
+      expect(resp.json).toEqual({ sum: 1000 });
     });
   }
 });

--- a/src/__tests__/TransformationApiDataStore.ts
+++ b/src/__tests__/TransformationApiDataStore.ts
@@ -1,4 +1,4 @@
-import { RestClient, RestApi, RequestBody, PathParam, QueryParams } from '../index';
+import { RestClient, RestApi, RequestBody, PathParam, QueryParams, ApiResponse } from '../index';
 
 interface NumberPair {
   a: number;
@@ -37,7 +37,7 @@ export class TransformationApiDataStore {
       );
     },
   })
-  doSimpleRequestTransformApi(@RequestBody requestBody: NumberPair): any {}
+  doSimpleRequestTransformApi(@RequestBody requestBody: NumberPair): ApiResponse {}
 
   // this example will make the api response to the backend
   // then transform the returned data by adding the 2 numbers a and b
@@ -57,7 +57,7 @@ export class TransformationApiDataStore {
       });
     },
   })
-  doSimpleResponseTransformApi(@RequestBody requestBody: NumberPair): any {}
+  doSimpleResponseTransformApi(@RequestBody requestBody: NumberPair): ApiResponse {}
 
   // this example will attempt making 2 async calls for 2 sums and then add them up
   // in the request body before sending them out to the backend
@@ -68,24 +68,41 @@ export class TransformationApiDataStore {
       fourNumbers: FourNumberCollection,
       instance: TransformationApiDataStore,
     ): Promise<Request> => {
-      const { a, b, c, d } = fourNumbers;
+      if (instance) {
+        const { a, b, c, d } = fourNumbers;
 
-      return Promise.all([
-        instance.doSimpleResponseTransformApi({ a: a, b: b }).result,
-        instance.doSimpleResponseTransformApi({ a: c, b: d }).result,
-      ]).then(([res1, res2]) => {
-        const sum1 = res1.sum;
-        const sum2 = res2.sum;
-        const totalAmount = sum1 + sum2;
-        const newBody = { totalAmount, sum1, sum2 };
+        const apiResponseSum1 = instance.doSimpleResponseTransformApi({ a: a, b: b });
+        const apiResponseSum2 = instance.doSimpleResponseTransformApi({ a: c, b: d });
 
-        return Promise.resolve(
-          Object.assign(fetchOptions, {
-            body: JSON.stringify(newBody),
-          }),
-        );
-      });
+        let totalAmount = 0;
+
+        if (!apiResponseSum1 || !apiResponseSum2) {
+          return Promise.resolve(
+            Object.assign(fetchOptions, {
+              totalAmount: 0,
+              error: 'One of the request for sum failed',
+            }),
+          ); // one of the sum failed, just return 0
+        }
+
+        return Promise.all([
+          apiResponseSum1 ? apiResponseSum1.result : 0,
+          apiResponseSum2 ? apiResponseSum2.result : 0,
+        ]).then(([res1, res2]) => {
+          const sum1 = res1.sum;
+          const sum2 = res2.sum;
+          const totalAmount = sum1 + sum2;
+          const newBody = { totalAmount, sum1, sum2 };
+
+          return Promise.resolve(
+            Object.assign(fetchOptions, {
+              body: JSON.stringify(newBody),
+            }),
+          );
+        });
+      }
+      return Promise.reject('Instance not available - cannot complete the calculation');
     },
   })
-  doComplexRequestTransformation(@RequestBody requestBody: FourNumberCollection): any {}
+  doComplexRequestTransformation(@RequestBody requestBody: FourNumberCollection): ApiResponse {}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,7 @@ enum HttpVerbEnum {
 type HttpVerb = HttpVerbEnum | 'GET' | 'POST' | 'DELETE' | 'PUT' | 'PATCH';
 
 // types
-interface IApiResponse {
+interface IApiResponse<T> {
   url: string;
   request_headers: object | null;
   request_body: any;
@@ -116,10 +116,10 @@ interface IApiResponse {
   status: number;
   statusText: string;
   ok: boolean;
-  result: Promise<any>; // this is a promise for response data
+  result: Promise<T>; // this is a promise for response data
   abort(); // used to abort the api
 }
-export type ApiResponse = IApiResponse | void;
+export type ApiResponse<T> = IApiResponse<T> | void;
 
 export interface RestClientOptions extends RequestInit {
   baseUrl: string;
@@ -238,7 +238,7 @@ export const RestApi = (url: string, restApiOptions: RestApiOptions = {}) => {
       const controller = new AbortController();
 
       // doing the request transform
-      const finalResp = <ApiResponse>{
+      const finalResp = <ApiResponse<any>>{
         abort: () => {
           controller.abort();
         }, // used to abort the api

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ interface IApiResponse {
   result: Promise<any>; // this is a promise for response data
   abort(); // used to abort the api
 }
-export type ApiResponse = IApiResponse | null;
+export type ApiResponse = IApiResponse | void;
 
 export interface RestClientOptions extends RequestInit {
   baseUrl: string;
@@ -244,7 +244,7 @@ export const RestApi = (url: string, restApiOptions: RestApiOptions = {}) => {
         }, // used to abort the api
       };
 
-      if(finalResp){
+      if (finalResp) {
         finalResp.result = request_transform(
           objectAssign(
             {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ const _defaultRequestTransform = (
 ): Promise<Request> => {
   let bodyToUse;
   switch (fetchOptionToUse.method) {
-    case HttpVerb.GET:
+    case HttpVerbEnum.GET:
       break;
 
     default:
@@ -68,9 +68,9 @@ const _getQueryParams = (instance, methodName, inputs) =>
 
 const _getCredential = (instance) => {
   switch (instance.authType) {
-    case AuthType.Bearer:
+    case AuthTypeEnum.Bearer:
       return instance[get(instance, ['__decorators', '@CredentialProperty', 'AccessToken'])];
-    case AuthType.Basic:
+    case AuthTypeEnum.Basic:
       const username = instance[get(instance, ['__decorators', '@CredentialProperty', 'Username'])];
       const password = instance[get(instance, ['__decorators', '@CredentialProperty', 'Password'])];
 
@@ -91,22 +91,24 @@ const _getBase64FromString = (str) => {
 };
 
 // enums
-enum AuthType {
+enum AuthTypeEnum {
   Basic = 'Basic',
   Bearer = 'Bearer',
   Digest = 'Digest', // TODO: support this
 }
+type AuthType = AuthTypeEnum | 'Basic' | 'Bearer' | 'Digest' | undefined;
 
-enum HttpVerb {
+enum HttpVerbEnum {
   GET = 'GET',
   POST = 'POST',
   DELETE = 'DELETE',
   PUT = 'PUT',
   PATCH = 'PATCH',
 }
+type HttpVerb = HttpVerbEnum | 'GET' | 'POST' | 'DELETE' | 'PUT' | 'PATCH';
 
 // types
-export interface ApiResponse {
+interface IApiResponse {
   url: string;
   request_headers: object | null;
   request_body: any;
@@ -117,15 +119,16 @@ export interface ApiResponse {
   result: Promise<any>; // this is a promise for response data
   abort(); // used to abort the api
 }
+export type ApiResponse = IApiResponse | null;
 
 export interface RestClientOptions extends RequestInit {
   baseUrl: string;
-  authType?: AuthType | 'Basic' | 'Bearer' | 'Digest' | undefined;
+  authType?: AuthType;
 }
 
 export interface RestApiOptions {
   headers?: Headers;
-  method?: HttpVerb | 'GET' | 'POST' | 'DELETE' | 'PUT' | 'PATCH';
+  method?: HttpVerb;
   request_transform?(fetchOptions: Request, body: object, instance: any): Promise<Request>;
   response_transform?(fetchOptions: Request, resp: Response, instance: any): Promise<any>;
 }
@@ -193,7 +196,7 @@ export const RestApi = (url: string, restApiOptions: RestApiOptions = {}) => {
   return (target: any, methodName: string | symbol, descriptor: any) => {
     const {
       headers = {},
-      method = HttpVerb.GET,
+      method = HttpVerbEnum.GET,
       request_transform = _defaultRequestTransform,
       response_transform = _defaultResponseTransform,
       ...otherFetchOptions
@@ -241,33 +244,35 @@ export const RestApi = (url: string, restApiOptions: RestApiOptions = {}) => {
         }, // used to abort the api
       };
 
-      finalResp.result = request_transform(
-        objectAssign(
-          {
-            url: urlToUse,
-            method: method.toUpperCase(),
-            signal: controller.signal,
-            headers: headersToUse,
-          },
-          otherFetchOptions,
-        ),
-        requestBody,
-        instance,
-      ).then((fetchOptionToUse) => {
-        finalResp.request_body = fetchOptionToUse.body;
-        finalResp.request_headers = fetchOptionToUse.headers;
+      if(finalResp){
+        finalResp.result = request_transform(
+          objectAssign(
+            {
+              url: urlToUse,
+              method: method.toUpperCase(),
+              signal: controller.signal,
+              headers: headersToUse,
+            },
+            otherFetchOptions,
+          ),
+          requestBody,
+          instance,
+        ).then((fetchOptionToUse) => {
+          finalResp.request_body = fetchOptionToUse.body;
+          finalResp.request_headers = fetchOptionToUse.headers;
 
-        return _fetchData(fetchOptionToUse).then((resp) => {
-          finalResp.url = resp.url;
-          finalResp.ok = resp.ok;
-          finalResp.status = resp.status;
-          finalResp.statusText = resp.statusText;
-          finalResp.response_headers = resp.headers;
+          return _fetchData(fetchOptionToUse).then((resp) => {
+            finalResp.url = resp.url;
+            finalResp.ok = resp.ok;
+            finalResp.status = resp.status;
+            finalResp.statusText = resp.statusText;
+            finalResp.response_headers = resp.headers;
 
-          // doing the response transform
-          return response_transform(fetchOptionToUse, resp, instance);
+            // doing the response transform
+            return response_transform(fetchOptionToUse, resp, instance);
+          });
         });
-      });
+      }
 
       return finalResp;
     };


### PR DESCRIPTION
- [X] Uses `ApiResponse` for return type instead of `any`
- [X] Consolidate enum / string types for `HttpVerb` and `AuthType`
- [X] Support Serialization of Response Object into custom type