### PR TITLE
Added docs and tests for config overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Another inspiration is to create a unified Rest Client library that works across
 - [X] Uses `ApiResponse` for return type instead of `any`
 - [X] Consolidate enum / string types for `HttpVerb` and `AuthType`
 - [X] Support Serialization of Response Object into custom type
-- [ ] Adds more examples / tests on how to override headers, and rest config from the `@RestClient` and `@RestApi`
+- [X] Adds more examples / tests on how to override headers, and rest config from the `@RestClient` and `@RestApi`
 - [ ] Cleanup / Refactor and export typescript types
 - [ ] Throw exception when missing key params
 - [ ] Add API retry actions
@@ -366,6 +366,47 @@ if(apiResponse){
   //... follow the above example to get the data from result promise
 }
 ```
+
+
+##### Config Overrides
+We have 3 layers of configs: `DefaultConfig` (default configs from this library), `@RestClient` Custom Configs and `@RestApi` Custom Configs. The final config values are set using this order `DefaultConfig`, `@RestClient`, and `@RestApi`.
+
+Below is an example on how to set Custom Config
+```
+import { RestClient, RestApi, RequestBody, PathParam, QueryParams, ApiResponse } from 'restapi-typescript-decorators';
+
+import { HttpBinPostResponse } from './HttpBinTypes';
+
+@RestClient({
+  baseUrl: 'https://httpbin.org',
+  headers: {
+    'Accept-Encoding': 'ASCII',
+    '--Rest-Client-Custom-Header': '<some_value_@Restclient_111>',
+    '--Rest-Api-Custom-Header': '<this_value_will_overrided>',
+  },
+})
+export class OverrideConfigApiDataStore {
+  @RestApi('/anything', {
+    method: 'POST',
+    mode: 'no-cors',
+    cache: 'reload',
+    credentials: 'same-origin',
+    headers: {
+      'Accept-Encoding': 'UTF8',
+      'Content-Type': '<some_value_@RestApi_333>',
+      '--Rest-Api-Custom-Header': '<some_value_@RestApi_222>',
+    },
+  })
+  doSimplePostWithCustomRestApiConfig(): ApiResponse<HttpBinPostResponse> {}
+}
+```
+
+With the above example
+- `--Rest-Api-Custom-Header`: will be `<some_value_@RestApi_222>` because it's set in @RestApi which has more specificity even though its value in `@RestClient` is `<this_value_will_overrided>`
+- `--Rest-Client-Custom-Header`: will be `<some_value_@Restclient_111>` because it's set inside of `@RestApi` although it's not defined anywhere else in `DefaultConfigs` or `@RestClient`
+- `Content-Type`: will be `application/json` because it's set in the `DefaultConfigs` even though we didn't specify it.
+
+
 
 #### Notes
 - For post method and post JSON body of `appplication/json`, the request will stringify and properly saves it into the body

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "restapi-typescript-decorators",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restapi-typescript-decorators",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Decorators that helps reduce the boilderplate code for rest api calls on the frontend and node js",
   "main": "build/index",
   "scripts": {

--- a/src/__tests__/HttpBinTypes.ts
+++ b/src/__tests__/HttpBinTypes.ts
@@ -6,7 +6,7 @@ export interface HttpBinAuthResponse {
 
 export interface HttpBinGetResponse {
   args?: object;
-  headers?: any;
+  headers?: object;
   origin?: string;
   url?: string;
   data?: object;

--- a/src/__tests__/HttpBinTypes.ts
+++ b/src/__tests__/HttpBinTypes.ts
@@ -6,7 +6,7 @@ export interface HttpBinAuthResponse {
 
 export interface HttpBinGetResponse {
   args?: object;
-  headers?: object;
+  headers?: any;
   origin?: string;
   url?: string;
   data?: object;

--- a/src/__tests__/OverrideConfigApiDataStore.spec.ts
+++ b/src/__tests__/OverrideConfigApiDataStore.spec.ts
@@ -1,0 +1,54 @@
+import { OverrideConfigApiDataStore } from './OverrideConfigApiDataStore';
+
+const myOverrideConfigApiDataStoreInstance = new OverrideConfigApiDataStore();
+
+test('Simple Override Config from @RestApi API should work', () => {
+  const apiResponse = myOverrideConfigApiDataStoreInstance.doSimplePostWithCustomRestApiConfig();
+
+  expect(apiResponse).toBeDefined();
+
+  if (apiResponse) {
+    return apiResponse.result.then((resp) => {
+      expect(apiResponse.ok).toBe(true);
+      expect(apiResponse.status).toEqual(200);
+      expect(resp).toBeDefined();
+
+      if (resp) {
+        const { headers } = resp;
+
+        if (headers) {
+          expect(headers['Accept']).toEqual('application/json');
+          expect(headers['--Rest-Client-Custom-Header']).toEqual('<some_value_@Restclient_111>');
+          expect(headers['--Rest-Api-Custom-Header']).toEqual('<some_value_@RestApi_222>');
+          expect(headers['Content-Type']).toEqual('<some_value_@RestApi_333>');
+          expect(headers['Accept-Encoding']).toEqual('UTF8');
+        }
+      }
+    });
+  }
+});
+
+test('Simple Override Config from @RestClient API should work', () => {
+  const apiResponse = myOverrideConfigApiDataStoreInstance.doSimplePostWithCustomRestClientConfig();
+
+  expect(apiResponse).toBeDefined();
+
+  if (apiResponse) {
+    return apiResponse.result.then((resp) => {
+      expect(apiResponse.ok).toBe(true);
+      expect(apiResponse.status).toEqual(200);
+      expect(resp).toBeDefined();
+
+      if (resp) {
+        const { headers } = resp;
+
+        if (headers) {
+          expect(headers['Accept']).toEqual('application/json');
+          expect(headers['--Rest-Client-Custom-Header']).toEqual('<some_value_@Restclient_111>');
+          expect(headers['--Rest-Api-Custom-Header']).toEqual('<this_value_will_overrided>');
+          expect(headers['Accept-Encoding']).toEqual('ASCII');
+        }
+      }
+    });
+  }
+});

--- a/src/__tests__/OverrideConfigApiDataStore.ts
+++ b/src/__tests__/OverrideConfigApiDataStore.ts
@@ -1,0 +1,31 @@
+import { RestClient, RestApi, RequestBody, PathParam, QueryParams, ApiResponse } from '../index';
+
+import { HttpBinPostResponse } from './HttpBinTypes';
+
+@RestClient({
+  baseUrl: 'https://httpbin.org',
+  headers: {
+    'Accept-Encoding': 'ASCII',
+    '--Rest-Client-Custom-Header': '<some_value_@Restclient_111>',
+    '--Rest-Api-Custom-Header': '<this_value_will_overrided>',
+  },
+})
+export class OverrideConfigApiDataStore {
+  @RestApi('/anything', {
+    method: 'POST',
+    mode: 'no-cors',
+    cache: 'reload',
+    credentials: 'same-origin',
+    headers: {
+      'Accept-Encoding': 'UTF8',
+      'Content-Type': '<some_value_@RestApi_333>',
+      '--Rest-Api-Custom-Header': '<some_value_@RestApi_222>',
+    },
+  })
+  doSimplePostWithCustomRestApiConfig(): ApiResponse<HttpBinPostResponse> {}
+
+  @RestApi('/anything', {
+    method: 'POST',
+  })
+  doSimplePostWithCustomRestClientConfig(): ApiResponse<HttpBinPostResponse> {}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,8 +127,11 @@ export interface RestClientOptions extends RequestInit {
 }
 
 export interface RestApiOptions {
-  headers?: Headers;
+  headers?: object;
   method?: HttpVerb;
+  mode?: string;
+  cache?: string;
+  credentials?: string;
   request_transform?(
     fetchOptions: Request,
     body: object,


### PR DESCRIPTION
- [X] Adds more examples / tests on how to override headers, and rest config from the `@RestClient` and `@RestApi`