### PR TITLE
Allow usage of `@PathParams` on `baseUrl`, and supports that `@PathParams` for Class Members and Method Params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,3 @@ typings/
 # src/**/*.js
 build
 .env
-
-
-.vscode

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,12 @@
+.gitignore
+.nvmrc
+.prettierrc
+.vscode
+build/__tests__
+coverage
 jest.config.js
+jest.setup.js
+mock-server
+SampleSms.txt
 src
 tsconfig.json
-.vscode
-build/__tests__/
-jest.setup.js
-.prettierrc

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Jest Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": [
+        "--inspect-brk",
+        "${workspaceRoot}/node_modules/.bin/jest",
+        "--runInBand",
+        "--coverage",
+        "false"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -690,11 +690,11 @@ export class TransformationApiDataStore {
       );
     },
   })
-  doSimpleRequestTransformApi(@RequestBody requestBody: NumberPair): ApiResponse<any> {}
+  doPostWithRequestTransformation(@RequestBody requestBody: NumberPair): ApiResponse<any> {}
 }
 
 const myTransformationApiDataStoreInstance = new TransformationApiDataStore();
-const apiResponse = myTransformationApiDataStoreInstance.doSimpleRequestTransformApi({ a: 1, b: 2 })
+const apiResponse = myTransformationApiDataStoreInstance.doPostWithRequestTransformation({ a: 1, b: 2 })
 
 if(apiResponse){
   //... follow the above example to get the data from result promise
@@ -740,11 +740,11 @@ export class TransformationApiDataStore {
       });
     },
   })
-  doSimpleResponseTransformApi(@RequestBody requestBody: NumberPair): ApiResponse<any> {}
+  doPostWithResponseTransformation(@RequestBody requestBody: NumberPair): ApiResponse<any> {}
 }
 
 const myTransformationApiDataStoreInstance = new TransformationApiDataStore();
-const apiResponse = myTransformationApiDataStoreInstance.doSimpleResponseTransformApi({ a: 300, b: 700 })
+const apiResponse = myTransformationApiDataStoreInstance.doPostWithResponseTransformation({ a: 300, b: 700 })
 
 if(apiResponse){
   //... follow the above example to get the data from result promise
@@ -803,7 +803,7 @@ export class OverrideConfigApiDataStore {
       '--Rest-Api-Custom-Header': '<some_value_@RestApi_222>',
     },
   })
-  doSimplePostWithCustomRestApiConfig(): ApiResponse<HttpBinResponse> {}
+  doPostWithCustomRestApiConfig(): ApiResponse<HttpBinResponse> {}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Inpsired by [retrofit](https://github.com/square/retrofit) (created by Square), 
 Another inspiration is to create a unified Rest Client library that works across the stack. In this case, to support node js and frontend code in a single code base. The goal is to create a single decorator for both node js and frontend.
 
 ### Features
-- [X] Supports for path params. See usages for `@PathParam`. Refer to [Using @PathParams Section](#simple-get-rest-calls-with-path-param) for more details.
+- [X] Supports for path params. `@PathParam` can be used in a class member or a method parameter. See usages for `@PathParam`. Refer to [Using @PathParams Section](#simple-get-rest-calls-with-path-param) for more details.
 - [X] Supports for query string. See usages for `@QueryParams`. Refer to [Using @QueryParams Section](#simple-get-rest-calls-with-query-string) for more details.
 - [X] Supports for POSTING JSON requests. See usages for `@RequestBody`. Refer to [Using @RequestBody Section](#simple-post-rest-calls-with-json-body) for more details.
 - [X] Supports POST raw data to API with `@FormDataBody`. Refer to [Using @FormData Section](#simple-post-rest-calls-with-formdata-body) for more details.
@@ -129,11 +129,17 @@ export interface HttpBinResponse {
 export class PublicApiDataStore {
   // do simple get with query params
   @RestApi('/get')
-  doSimpleHttpBinGet(@QueryParams _queryParams: HttpBinRequest): ApiResponse<HttpBinResponse> {}
+  doGetWithQueryParams(@QueryParams _queryParams: HttpBinRequest): ApiResponse<HttpBinResponse> {}
+
+  // do simple get with absolute URL
+  // this example will use url defined here
+  // instead of appended it to the baseUrl
+  @RestApi('https://httpbin.org/get')
+  doGetWithAbsoluteUrl(): ApiResponse<HttpBinResponse> {}
 
   // do simple get with path params
   @RestApi('/anything/{messageId}')
-  doSimpleHttpBinPathParamsGet(
+  doGetWithPathParamsAndQueryParams(
     @PathParam('messageId') _targetMessageId: string,
     @QueryParams _queryParams: HttpBinRequest,
   ): ApiResponse<HttpBinResponse> {}
@@ -143,14 +149,14 @@ export class PublicApiDataStore {
   @RestApi('/delay/10', {
     timeout: 3000,
   })
-  doSimpleTimeoutAPI(): ApiResponse<HttpBinResponse> {}
+  doGetWithTimeout(): ApiResponse<HttpBinResponse> {}
 
   // this API will always return 405 error
   @RestApi('/status/405')
-  doSimpleErroneousAPI(): ApiResponse<HttpBinResponse> {}
+  doErroneousAPI(): ApiResponse<HttpBinResponse> {}
 
   @RestApi('/{encodingToUse}')
-  doSimpleHttpGetWithEncoding(
+  doGetWithResponseEncoding(
     @PathParam('encodingToUse') _encoding: 'brotli' | 'gzip' | 'deflate',
   ): ApiResponse<HttpBinResponse> {}
 
@@ -159,13 +165,13 @@ export class PublicApiDataStore {
       Accept: 'application/xml',
     },
   })
-  doSimpleHttpGetWithXmlData(): ApiResponse<HttpBinResponse> {}
+  doGetWithXmlResponse(): ApiResponse<HttpBinResponse> {}
 
   // do simple post with JSON request body
   @RestApi('/post', {
     method: 'POST',
   })
-  doSimpleHttpBinPostJsonBody(@RequestBody _body: HttpBinRequest): ApiResponse<HttpBinResponse> {}
+  doPostWithJsonBody(@RequestBody _body: HttpBinRequest): ApiResponse<HttpBinResponse> {}
 
   // do simple post with URL encoded form request body
   @RestApi('/post', {
@@ -174,7 +180,7 @@ export class PublicApiDataStore {
       'Content-Type': 'application/x-www-form-urlencoded',
     },
   })
-  doSimpleHttpBinPostEncodedForm(
+  doPostWithEncodedFormData(
     @RequestBody _body: HttpBinRequest,
   ): ApiResponse<HttpBinResponse> {}
 
@@ -182,7 +188,7 @@ export class PublicApiDataStore {
   @RestApi('/anything', {
     method: 'POST',
   })
-  doSimpleFormDataHttpBinPost(
+  doPostWithFormBodyData(
     @FormDataBody('unitPrice') _unitPrice: number,
     @FormDataBody('quantity') _qty: number,
   ): ApiResponse<HttpBinResponse> {}
@@ -191,7 +197,7 @@ export class PublicApiDataStore {
   @RestApi('/anything', {
     method: 'POST',
   })
-  doSimpleUploadFileHttpBinPost(
+  doUploadFileWithFormBodyData(
     @FormDataBody('mySms') _mySmsContent: HttpBinRequest,
   ): ApiResponse<HttpBinResponse> {}
 
@@ -199,23 +205,21 @@ export class PublicApiDataStore {
   @RestApi('/post', {
     method: 'POST',
   })
-  doSimpleUploadFileWithStreamHttpBinPost(
+  doUploadFileWithStreamRequest(
     @FileUploadBody _fileToUpload: any,
   ): ApiResponse<HttpBinResponse> {}
 }
-
-
 ```
 
 **Then instantiate it as**
 ```
 import { PublicApiDataStore } from './PublicApiDataStore';
-const myRestClientInstance = new PublicApiDataStore();
+const myApiInstance = new PublicApiDataStore();
 ```
 
 **Use it**
 ```
-apiResponse = myRestClientInstance.doSimpleHttpBinGet({a: 1, b: 2});
+apiResponse = myApiInstance.doGetWithQueryParams({a: 1, b: 2});
 if(apiResponse){
   apiResponse.result.then(
     resp => {
@@ -265,20 +269,19 @@ export class PrivateBearerAuthApiDataStore {
   @RestApi('/bearer', {
     method: 'GET',
   })
-  doApiCallWithBearerToken(): ApiResponse<HttpBinAuthResponse> {}
+  doAuthenticatedCall(): ApiResponse<HttpBinAuthResponse> {}
 }
 ```
 
 **Then instantiate it as**
 ```
 import { PrivateBearerAuthApiDataStore } from './PrivateBearerAuthApiDataStore';
-const myRestClientInstance = new PrivateBearerAuthApiDataStore(
+const myApiInstance = new PrivateBearerAuthApiDataStore(
   'good_username',
   'good_password'
 );
 
-
-// refer to other section for how to execute the calls
+// ... refer to other section for how to execute the calls
 ```
 
 
@@ -325,27 +328,27 @@ export class PrivateBasicAuthApiDataStore {
   @RestApi('/basic-auth/good_username/good_password', {
     method: 'GET',
   })
-  doApiCallWithBasicUsernameAndPassword(): ApiResponse<HttpBinAuthResponse> {}
+  doAuthenticatedCall(): ApiResponse<HttpBinAuthResponse> {}
 }
 ```
 
 **Then instantiate it as**
 ```
 import { PrivateBasicAuthApiDataStore } from './PrivateBasicAuthApiDataStore';
-const myRestClientInstance = new PrivateBasicAuthApiDataStore(
+const myApiInstance = new PrivateBasicAuthApiDataStore(
   'good_username',
   'good_password'
 );
 
-// refer to other section for how to execute the calls
+// ... refer to other section for how to execute the calls
 ```
 
 
 #### To execute the RestClient
 ```
-const myRestClientInstance = new PrivateApiDataStore('<<some_strong_and_random_access_token>>');
+const myApiInstance = new PrivateApiDataStore('<<some_strong_and_random_access_token>>');
 
-const apiResponse = myRestClientInstance.doApiCallWithBearerToken();
+const apiResponse = myApiInstance.doApiCallWithBearerToken();
 
 if(apiResponse){
   apiResponse.result.then((resp) => {
@@ -364,7 +367,7 @@ Sometimes you want to abort a pending Rest call. You can use `apiResponse.abort(
 ```
 // ... your construction code here ...
 
-const apiResponse = myRestClientInstance.doApiCallWithBearerToken();
+const apiResponse = myApiInstance.doApiCallWithBearerToken();
 
 if(apiResponse){
   apiResponse.result.then((resp) => {
@@ -376,48 +379,67 @@ if(apiResponse){
 ```
 
 #### Simple GET REST Calls with Query String
+This will send a GET request to the backend with query string attached. The library will handle url encoding for your data. So no need to encode it when using this API.
 ```
-@RestApi("/get")
-doSimpleHttpBinGet(@QueryParams _queryParams: any): ApiResponse<any> {}
+@RestApi('/get')
+doGetWithQueryParams(@QueryParams _queryParams: HttpBinRequest): ApiResponse<HttpBinResponse> {}
 ```
 
 #### Simple GET REST Calls with Path Param
+@PathParams can be used in a class members (class attributes) or method parameters.
+
+Below is an example of how path params can be used in a class member
 ```
 @RestApi("/anything/{messageId}")
-doSimpleHttpBinPathParamsGet(
+doGetWithPathParams(
   @PathParam("messageId") _targetMessageId: string
 ): ApiResponse<any> {}
 ```
 
+The following code shows how path params can be used in class members and method parameters
+```
+@RestClient({
+  baseUrl: 'https://httpbin.org/cookies/set/{cookieName}/{cookieValue}',
+})
+export class PathParamApiDataStore {
+  @PathParam('cookieName')
+  cookieName: string;
+
+  constructor(newCookieName: string = '') {
+    this.cookieName = newCookieName;
+  }
+
+  @RestApi()
+  doGet(@PathParam('cookieValue') _newCookieValue: string): ApiResponse<HttpBinResponse> {}
+}
+```
+
 #### Simple GET REST Calls with Path Param and Query String
 ```
-@RestApi("/anything/{messageId}")
-doSimpleHttpBinPathParamsGet(
-  @PathParam("messageId") _targetMessageId : string,
-  @QueryParams _queryParams: any
-): ApiResponse<any> {}
+@RestApi('/anything/{messageId}')
+doGetWithPathParamsAndQueryParams(
+  @PathParam('messageId') _targetMessageId: string,
+  @QueryParams _queryParams: HttpBinRequest,
+): ApiResponse<HttpBinResponse> {}
 ```
 
 #### Simple POST Rest Calls with JSON Body
 ```
-@RestApi("/post", {
-  method: "POST",
+@RestApi('/post', {
+  method: 'POST',
 })
-doSimpleHttpBinPost(@RequestBody _body: any): ApiResponse<any> {}
+doPostWithJsonBody(@RequestBody _body: HttpBinRequest): ApiResponse<HttpBinResponse> {}
 ```
 
 
 #### Simple POST Rest Calls with FormData Body
-The following will make a POST to the API with the form data body:
-`unitPrice=val1&qty=val2`
-
 ```
 @RestApi('/anything', {
   method: 'POST',
 })
-doSimpleFormDataHttpBinPost(
-  @FormDataBody('unitPrice') unitPrice: number,
-  @FormDataBody('quantity') qty: number,
+doPostWithFormBodyData(
+  @FormDataBody('unitPrice') _unitPrice: number,
+  @FormDataBody('quantity') _qty: number,
 ): ApiResponse<HttpBinResponse> {}
 ```
 
@@ -446,6 +468,18 @@ const apiResponse = myPublicDataStoreInstance.doSimpleUploadFileWithStreamHttpBi
 );
 ```
 
+#### URL Notes
+By default, the library will construct the url to use as:
+
+- When `@RestApi.url` is a relative url (for example "`/myAPI`"). The url by appended the `url` from `@RestApi` to `baseUrl` from `@RestClient` as:
+```
+urlToUse = @RestClient.baseUrl + @RestApi.url
+```
+
+- When `@RestApi.url` is an absolute url which starts with `http://` or `https://` (for example "`https://httpbin.org/get`" or "`http://httpbin.org/get`"). That absolute url will be used and won't be appended to the `baseUrl`
+```
+urlToUse = @RestApi.url
+```
 
 #### Type casting your response type
 Sometimes it might be useful to cast / parsing the json object in the response to match certain object type. We can do so with this library using this approach.
@@ -483,7 +517,7 @@ export class TypeCastApiDataStore {
   @RestApi('/calculateSum', {
     method: 'POST',
   })
-  doSimpleResponseTransformApi(@RequestBody requestBody: NumberPair): ApiResponse<CollectionSum> {}
+  doPostWithTypeCasting(@RequestBody requestBody: NumberPair): ApiResponse<CollectionSum> {}
 }
 ```
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,5 @@ module.exports = {
   moduleNameMapper: {
     "restapi-typescript-decorators": "<rootDir>/src/index",
   },
+  collectCoverage: true,
 };

--- a/mock-server/index.js
+++ b/mock-server/index.js
@@ -1,23 +1,20 @@
 var restify = require('restify');
 var errs = require('restify-errors');
 
-
-
 function between(min, max) {
   return Math.floor(Math.random() * (max - min) + min);
 }
 
 function respondWithNoExtraHeader(req, res, next) {
   const num = between(1, 10);
-  if(num <= 4){
+  if (num <= 4) {
     res.send({ code: 'OK', message: 'SUCCESS' });
     next();
   } else {
-    res.status(500)
-    res.send({ error: 'API failed' })
+    res.status(500);
+    res.send({ error: 'API failed' });
   }
 }
-
 
 function respondWithRetryAfterHeader(req, res, next) {
   const num = between(1, 10);
@@ -26,9 +23,9 @@ function respondWithRetryAfterHeader(req, res, next) {
     next();
   } else {
     const retryAfterSeconds = between(1, 5);
-    res.status(500)
-    res.header('Retry-After', retryAfterSeconds)
-    res.send({ error: 'API failed', retryAfter: retryAfterSeconds })
+    res.status(500);
+    res.header('Retry-After', retryAfterSeconds);
+    res.send({ error: 'API failed', retryAfter: retryAfterSeconds });
     next();
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "restapi-typescript-decorators",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "restapi-typescript-decorators",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restapi-typescript-decorators",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Decorators that helps reduce the boilderplate code for rest api calls on the frontend and node js",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/__tests__/OverrideConfigApiDataStore.spec.ts
+++ b/src/__tests__/OverrideConfigApiDataStore.spec.ts
@@ -1,10 +1,10 @@
 import { OverrideConfigApiDataStore } from './OverrideConfigApiDataStore';
 
-const myOverrideConfigApiDataStoreInstance = new OverrideConfigApiDataStore();
+const myApiInstance = new OverrideConfigApiDataStore();
 
 describe('OverrideConfigApiDataStore', () => {
-  it('Simple Override Config from @RestApi API should work', () => {
-    const apiResponse = myOverrideConfigApiDataStoreInstance.doSimplePostWithCustomRestApiConfig();
+  it('Override Config from @RestApi API should work', () => {
+    const apiResponse = myApiInstance.doPostWithCustomRestApiConfig();
 
     expect(apiResponse).toBeDefined();
 
@@ -29,8 +29,8 @@ describe('OverrideConfigApiDataStore', () => {
     }
   });
 
-  it('Simple Override Config from @RestClient API should work', () => {
-    const apiResponse = myOverrideConfigApiDataStoreInstance.doSimplePostWithCustomRestClientConfig();
+  it('Override Config from @RestClient API should work', () => {
+    const apiResponse = myApiInstance.doPostWithCustomRestClientConfig();
 
     expect(apiResponse).toBeDefined();
 

--- a/src/__tests__/OverrideConfigApiDataStore.ts
+++ b/src/__tests__/OverrideConfigApiDataStore.ts
@@ -30,10 +30,10 @@ export class OverrideConfigApiDataStore {
       '--Rest-Api-Custom-Header': '<some_value_@RestApi_222>',
     },
   })
-  doSimplePostWithCustomRestApiConfig(): ApiResponse<HttpBinResponse> {}
+  doPostWithCustomRestApiConfig(): ApiResponse<HttpBinResponse> {}
 
   @RestApi('/anything', {
     method: 'POST',
   })
-  doSimplePostWithCustomRestClientConfig(): ApiResponse<HttpBinResponse> {}
+  doPostWithCustomRestClientConfig(): ApiResponse<HttpBinResponse> {}
 }

--- a/src/__tests__/OverrideTransformDataStore.spec.ts
+++ b/src/__tests__/OverrideTransformDataStore.spec.ts
@@ -1,10 +1,10 @@
 import { OverrideTransformDataStore } from './OverrideTransformDataStore';
 
-const myOverrideTransformDataStoreInstance = new OverrideTransformDataStore();
+const myApiInstance = new OverrideTransformDataStore();
 
 describe('OverrideTransformDataStore', () => {
-  it('Simple Override of Transformation at @RestClient should work - example 1', () => {
-    const apiResponse = myOverrideTransformDataStoreInstance.doSimpleHttpBinPost({
+  it('Override of Transformation at @RestClient should work - example 1', () => {
+    const apiResponse = myApiInstance.doPost({
       a: 1,
       b: 2,
       c: 3,
@@ -21,8 +21,8 @@ describe('OverrideTransformDataStore', () => {
     }
   });
 
-  it('Simple Override of Transformation at @RestClient should work - example 2', () => {
-    const apiResponse = myOverrideTransformDataStoreInstance.doSimpleHttpBinGet({
+  it('Override of Transformation at @RestClient should work - example 2', () => {
+    const apiResponse = myApiInstance.doGet({
       d: 4,
       e: 5,
       f: 6,

--- a/src/__tests__/OverrideTransformDataStore.ts
+++ b/src/__tests__/OverrideTransformDataStore.ts
@@ -30,7 +30,7 @@ export class OverrideTransformDataStore {
   @RestApi('/post', {
     method: 'POST',
   })
-  doSimpleHttpBinPost(@RequestBody _body: HttpBinRequest): ApiResponse<HttpBinResponse> {}
+  doPost(@RequestBody _body: HttpBinRequest): ApiResponse<HttpBinResponse> {}
 
   @RestApi('/get', {
     responseTransform: (
@@ -46,5 +46,5 @@ export class OverrideTransformDataStore {
       });
     },
   })
-  doSimpleHttpBinGet(@QueryParams _queryParams: HttpBinRequest): ApiResponse<HttpBinResponse> {}
+  doGet(@QueryParams _queryParams: HttpBinRequest): ApiResponse<HttpBinResponse> {}
 }

--- a/src/__tests__/PathParamApiDataStore.spec.ts
+++ b/src/__tests__/PathParamApiDataStore.spec.ts
@@ -1,0 +1,24 @@
+import { PathParamApiDataStore } from './PathParamApiDataStore';
+
+const myApiInstance = new PathParamApiDataStore('mySecretCookie');
+
+// NOTE: this test can only be run against the custom server which we have here in this repo.
+// to run this test, start that Node server and remove the `skip` to re-run the test
+describe('PathParamApiDataStore', () => {
+  it('Complicated path params from method parameters and class members should work', () => {
+    const apiResponse = myApiInstance.doGet('mySecretValue_123_456_789');
+
+    expect(apiResponse).toBeDefined();
+
+    if (apiResponse) {
+      return apiResponse.result.then((resp) => {
+        expect(apiResponse.ok).toBe(true);
+        expect(apiResponse.status).toEqual(200);
+        expect(apiResponse.retryCount).toBeGreaterThan(0);
+        expect(apiResponse.url).toEqual(
+          'https://httpbin.org/cookies/set/mySecretCookie/mySecretValue_123_456_789',
+        );
+      });
+    }
+  });
+});

--- a/src/__tests__/PathParamApiDataStore.ts
+++ b/src/__tests__/PathParamApiDataStore.ts
@@ -1,0 +1,26 @@
+import {
+  RestClient,
+  RestApi,
+  RequestBody,
+  PathParam,
+  QueryParams,
+  FormDataBody,
+  ApiResponse,
+} from 'restapi-typescript-decorators';
+
+import { HttpBinResponse, HttpBinRequest } from './types';
+
+@RestClient({
+  baseUrl: 'https://httpbin.org/cookies/set/{cookieName}/{cookieValue}',
+})
+export class PathParamApiDataStore {
+  @PathParam('cookieName')
+  cookieName: string;
+
+  constructor(newCookieName: string = '') {
+    this.cookieName = newCookieName;
+  }
+
+  @RestApi()
+  doGet(@PathParam('cookieValue') _newCookieValue: string): ApiResponse<HttpBinResponse> {}
+}

--- a/src/__tests__/PrivateBasicAuthApiDataStore.spec.ts
+++ b/src/__tests__/PrivateBasicAuthApiDataStore.spec.ts
@@ -1,11 +1,12 @@
 import { PrivateBasicAuthApiDataStore } from './PrivateBasicAuthApiDataStore';
 
-const validDataStore = new PrivateBasicAuthApiDataStore('good_username', 'good_password');
-const invalidDataStore = new PrivateBasicAuthApiDataStore('bogus_u1', 'bogus_pwd1');
+const myGoodApiInstance = new PrivateBasicAuthApiDataStore('good_username', 'good_password');
+const myBadApiInstanceBogusCreds = new PrivateBasicAuthApiDataStore('bogus_u1', 'bogus_pwd1');
+const myBadApiInstanceEmptyCreds = new PrivateBasicAuthApiDataStore('', '');
 
 describe('PrivateBasicAuthApiDataStore', () => {
   it('Basic Auth Private Authenticated API Should work with good credentials', () => {
-    const apiResponse = validDataStore.doAuthenticatedCall();
+    const apiResponse = myGoodApiInstance.doAuthenticatedCall();
 
     expect(apiResponse).toBeDefined();
 
@@ -21,7 +22,23 @@ describe('PrivateBasicAuthApiDataStore', () => {
   });
 
   it('Basic Auth Private Authenticated API Should fail with bad credentials', () => {
-    const apiResponse = invalidDataStore.doAuthenticatedCall();
+    const apiResponse = myBadApiInstanceBogusCreds.doAuthenticatedCall();
+
+    expect(apiResponse).toBeDefined();
+
+    if (apiResponse) {
+      return apiResponse.result.catch((resp) => {
+        expect(apiResponse.url).toBe('https://httpbin.org/basic-auth/good_username/good_password');
+        expect(apiResponse.ok).toBe(false);
+        expect(apiResponse.status).toBe(401);
+        expect(apiResponse.statusText).toBe('UNAUTHORIZED');
+        expect(resp).toBe('');
+      });
+    }
+  });
+
+  it('Basic Auth Private Authenticated API Should fail with empty credentials', () => {
+    const apiResponse = myBadApiInstanceEmptyCreds.doAuthenticatedCall();
 
     expect(apiResponse).toBeDefined();
 

--- a/src/__tests__/PrivateBasicAuthApiDataStore.spec.ts
+++ b/src/__tests__/PrivateBasicAuthApiDataStore.spec.ts
@@ -4,8 +4,8 @@ const validDataStore = new PrivateBasicAuthApiDataStore('good_username', 'good_p
 const invalidDataStore = new PrivateBasicAuthApiDataStore('bogus_u1', 'bogus_pwd1');
 
 describe('PrivateBasicAuthApiDataStore', () => {
-  it('Simple Basic Auth Private Authenticated API Should work with good credentials', () => {
-    const apiResponse = validDataStore.doApiCallWithBasicUsernameAndPassword();
+  it('Basic Auth Private Authenticated API Should work with good credentials', () => {
+    const apiResponse = validDataStore.doAuthenticatedCall();
 
     expect(apiResponse).toBeDefined();
 
@@ -20,8 +20,8 @@ describe('PrivateBasicAuthApiDataStore', () => {
     }
   });
 
-  it('Simple Basic Auth Private Authenticated API Should fail with bad credentials', () => {
-    const apiResponse = invalidDataStore.doApiCallWithBasicUsernameAndPassword();
+  it('Basic Auth Private Authenticated API Should fail with bad credentials', () => {
+    const apiResponse = invalidDataStore.doAuthenticatedCall();
 
     expect(apiResponse).toBeDefined();
 

--- a/src/__tests__/PrivateBasicAuthApiDataStore.ts
+++ b/src/__tests__/PrivateBasicAuthApiDataStore.ts
@@ -30,5 +30,5 @@ export class PrivateBasicAuthApiDataStore {
   @RestApi('/basic-auth/good_username/good_password', {
     method: 'GET',
   })
-  doApiCallWithBasicUsernameAndPassword(): ApiResponse<HttpBinAuthResponse> {}
+  doAuthenticatedCall(): ApiResponse<HttpBinAuthResponse> {}
 }

--- a/src/__tests__/PrivateBearerAuthApiDataStore.spec.ts
+++ b/src/__tests__/PrivateBearerAuthApiDataStore.spec.ts
@@ -6,8 +6,8 @@ const invalidDataStore = new PrivateBearerAuthApiDataStore('');
 const validDataStore = new PrivateBearerAuthApiDataStore(testAccessToken);
 
 describe('PrivateBearerAuthApiDataStore', () => {
-  it('Simple Private Authenticated API Should work with correct access token', () => {
-    const apiResponse = validDataStore.doApiCallWithBearerToken();
+  it('Private Authenticated API Should work with correct access token', () => {
+    const apiResponse = validDataStore.doAuthenticatedCall();
 
     expect(apiResponse).toBeDefined();
 
@@ -22,8 +22,8 @@ describe('PrivateBearerAuthApiDataStore', () => {
     }
   });
 
-  it('Simple Private Authenticated API Should fail with no access token', () => {
-    const apiResponse = invalidDataStore.doApiCallWithBearerToken();
+  it('Private Authenticated API Should fail with no access token', () => {
+    const apiResponse = invalidDataStore.doAuthenticatedCall();
 
     expect(apiResponse).toBeDefined();
 

--- a/src/__tests__/PrivateBearerAuthApiDataStore.spec.ts
+++ b/src/__tests__/PrivateBearerAuthApiDataStore.spec.ts
@@ -2,12 +2,12 @@ import { PrivateBearerAuthApiDataStore } from './PrivateBearerAuthApiDataStore';
 
 const testAccessToken = '<<some_strong_and_random_access_token>>';
 
-const invalidDataStore = new PrivateBearerAuthApiDataStore('');
-const validDataStore = new PrivateBearerAuthApiDataStore(testAccessToken);
+const myBadApiInstance = new PrivateBearerAuthApiDataStore('');
+const myGoodApiInstance = new PrivateBearerAuthApiDataStore(testAccessToken);
 
 describe('PrivateBearerAuthApiDataStore', () => {
   it('Private Authenticated API Should work with correct access token', () => {
-    const apiResponse = validDataStore.doAuthenticatedCall();
+    const apiResponse = myGoodApiInstance.doAuthenticatedCall();
 
     expect(apiResponse).toBeDefined();
 
@@ -23,7 +23,7 @@ describe('PrivateBearerAuthApiDataStore', () => {
   });
 
   it('Private Authenticated API Should fail with no access token', () => {
-    const apiResponse = invalidDataStore.doAuthenticatedCall();
+    const apiResponse = myBadApiInstance.doAuthenticatedCall();
 
     expect(apiResponse).toBeDefined();
 

--- a/src/__tests__/PrivateBearerAuthApiDataStore.ts
+++ b/src/__tests__/PrivateBearerAuthApiDataStore.ts
@@ -26,5 +26,5 @@ export class PrivateBearerAuthApiDataStore {
   @RestApi('/bearer', {
     method: 'GET',
   })
-  doApiCallWithBearerToken(): ApiResponse<HttpBinAuthResponse> {}
+  doAuthenticatedCall(): ApiResponse<HttpBinAuthResponse> {}
 }

--- a/src/__tests__/PublicApiDataStore.spec.ts
+++ b/src/__tests__/PublicApiDataStore.spec.ts
@@ -236,4 +236,18 @@ describe('PublicApiDataStore', () => {
       });
     }
   });
+
+  it('Simple Plain Text Response should work', () => {
+    const apiResponse = myApiInstance.doGetWithPlainTextResponse();
+
+    expect(apiResponse).toBeDefined();
+
+    if (apiResponse) {
+      return apiResponse.result.then((resp) => {
+        expect(apiResponse.ok).toBe(true);
+        expect(apiResponse.status).toBe(200);
+        expect(resp).toMatchSnapshot();
+      });
+    }
+  });
 });

--- a/src/__tests__/PublicApiDataStore.spec.ts
+++ b/src/__tests__/PublicApiDataStore.spec.ts
@@ -1,12 +1,12 @@
 import { PublicApiDataStore } from './PublicApiDataStore';
 import fs from 'fs';
 
-const myPublicDataStoreInstance = new PublicApiDataStore();
+const myApiInstance = new PublicApiDataStore();
 const sampleTextFile = 'SampleSms.txt';
 
 describe('PublicApiDataStore', () => {
-  it('Simple Public HTTP POST with JSON @RequestBody should work', () => {
-    const apiResponse = myPublicDataStoreInstance.doSimpleHttpBinPostJsonBody({ a: 1, b: 2, c: 3 });
+  it('POST with JSON @RequestBody should work', () => {
+    const apiResponse = myApiInstance.doPostWithJsonBody({ a: 1, b: 2, c: 3 });
 
     expect(apiResponse).toBeDefined();
 
@@ -20,8 +20,8 @@ describe('PublicApiDataStore', () => {
     }
   });
 
-  it('Simple Public HTTP POST with encoded form @RequestBody should work', () => {
-    const apiResponse = myPublicDataStoreInstance.doSimpleHttpBinPostEncodedForm({
+  it('POST with encoded form @RequestBody should work', () => {
+    const apiResponse = myApiInstance.doPostWithEncodedFormData({
       a: 1,
       b: 2,
       c: 3,
@@ -39,8 +39,8 @@ describe('PublicApiDataStore', () => {
     }
   });
 
-  it('Simple Public HTTP GET with query params should work', () => {
-    const apiResponse = myPublicDataStoreInstance.doSimpleHttpBinGet({ a: 1, b: 2, c: 3 });
+  it('GET with query params should work', () => {
+    const apiResponse = myApiInstance.doGetWithQueryParams({ a: 1, b: 2, c: 3 });
 
     expect(apiResponse).toBeDefined();
 
@@ -54,15 +54,26 @@ describe('PublicApiDataStore', () => {
     }
   });
 
-  it('Simple Public HTTP GET with path params and query params should work', () => {
-    const apiResponse = myPublicDataStoreInstance.doSimpleHttpBinPathParamsGet(
-      'secret_message_id_123',
-      {
-        aa: 1,
-        bb: 2,
-        cc: 3,
-      },
-    );
+  it('GET with absolute URL should work', () => {
+    const apiResponse = myApiInstance.doGetWithAbsoluteUrl();
+
+    expect(apiResponse).toBeDefined();
+
+    if (apiResponse) {
+      return apiResponse.result.then((resp) => {
+        expect(apiResponse.ok).toBe(true);
+        expect(apiResponse.status).toBe(200);
+        expect(resp.url).toEqual('https://httpbin.org/get');
+      });
+    }
+  });
+
+  it('GET with path params and query params should work', () => {
+    const apiResponse = myApiInstance.doGetWithPathParamsAndQueryParams('secret_message_id_123', {
+      aa: 1,
+      bb: 2,
+      cc: 3,
+    });
 
     expect(apiResponse).toBeDefined();
 
@@ -78,8 +89,8 @@ describe('PublicApiDataStore', () => {
     }
   });
 
-  it('Simple Public HTTP POST with form data should work', () => {
-    const apiResponse = myPublicDataStoreInstance.doSimpleFormDataHttpBinPost(
+  it('POST with form data should work', () => {
+    const apiResponse = myApiInstance.doPostWithFormBodyData(
       123, // unit price
       100, // qty
     );
@@ -106,12 +117,10 @@ describe('PublicApiDataStore', () => {
     }
   });
 
-  it('Simple Public HTTP POST to upload binary file using form data should work', () => {
+  it('POST to upload binary file using form data should work', () => {
     const sampleSmsFileStream = fs.createReadStream(sampleTextFile);
 
-    const apiResponse = myPublicDataStoreInstance.doSimpleUploadFileHttpBinPost(
-      sampleSmsFileStream,
-    );
+    const apiResponse = myApiInstance.doUploadFileWithFormBodyData(sampleSmsFileStream);
 
     expect(apiResponse).toBeDefined();
 
@@ -124,12 +133,10 @@ describe('PublicApiDataStore', () => {
     }
   });
 
-  it('Simple Public HTTP POST to upload binary file using a single stream should work', () => {
+  it('POST to upload binary file using a single stream should work', () => {
     const sampleSmsFileStream = fs.createReadStream(sampleTextFile);
 
-    const apiResponse = myPublicDataStoreInstance.doSimpleUploadFileWithStreamHttpBinPost(
-      sampleSmsFileStream,
-    );
+    const apiResponse = myApiInstance.doUploadFileWithStreamRequest(sampleSmsFileStream);
 
     expect(apiResponse).toBeDefined();
 
@@ -143,7 +150,7 @@ describe('PublicApiDataStore', () => {
   });
 
   it('Simple Timeout API HTTP GET should work', (done) => {
-    const apiResponse = myPublicDataStoreInstance.doSimpleTimeoutAPI();
+    const apiResponse = myApiInstance.doGetWithTimeout();
 
     expect(apiResponse).toBeDefined();
 
@@ -161,7 +168,7 @@ describe('PublicApiDataStore', () => {
   });
 
   it('Simple Erroneous API HTTP GET should always fail', () => {
-    const apiResponse = myPublicDataStoreInstance.doSimpleErroneousAPI();
+    const apiResponse = myApiInstance.doErroneousAPI();
 
     expect(apiResponse).toBeDefined();
 
@@ -175,7 +182,7 @@ describe('PublicApiDataStore', () => {
   });
 
   it('`brotli` Accept-Encoding should work', () => {
-    const apiResponse = myPublicDataStoreInstance.doSimpleHttpGetWithEncoding('brotli');
+    const apiResponse = myApiInstance.doGetWithResponseEncoding('brotli');
 
     expect(apiResponse).toBeDefined();
 
@@ -189,7 +196,7 @@ describe('PublicApiDataStore', () => {
   });
 
   it('`deflate` Accept-Encoding should work', () => {
-    const apiResponse = myPublicDataStoreInstance.doSimpleHttpGetWithEncoding('deflate');
+    const apiResponse = myApiInstance.doGetWithResponseEncoding('deflate');
 
     expect(apiResponse).toBeDefined();
 
@@ -203,7 +210,7 @@ describe('PublicApiDataStore', () => {
   });
 
   it('`gzip` Accept-Encoding should work', () => {
-    const apiResponse = myPublicDataStoreInstance.doSimpleHttpGetWithEncoding('gzip');
+    const apiResponse = myApiInstance.doGetWithResponseEncoding('gzip');
 
     expect(apiResponse).toBeDefined();
 
@@ -217,7 +224,7 @@ describe('PublicApiDataStore', () => {
   });
 
   it('Simple XML Response should work', () => {
-    const apiResponse = myPublicDataStoreInstance.doSimpleHttpGetWithXmlData();
+    const apiResponse = myApiInstance.doGetWithXmlResponse();
 
     expect(apiResponse).toBeDefined();
 

--- a/src/__tests__/PublicApiDataStore.ts
+++ b/src/__tests__/PublicApiDataStore.ts
@@ -55,6 +55,13 @@ export class PublicApiDataStore {
   })
   doGetWithXmlResponse(): ApiResponse<HttpBinResponse> {}
 
+  @RestApi('/robots.txt', {
+    headers: {
+      Accept: 'text/plain',
+    },
+  })
+  doGetWithPlainTextResponse(): ApiResponse<string> {}
+
   // do simple post with JSON request body
   @RestApi('/post', {
     method: 'POST',
@@ -68,9 +75,7 @@ export class PublicApiDataStore {
       'Content-Type': 'application/x-www-form-urlencoded',
     },
   })
-  doPostWithEncodedFormData(
-    @RequestBody _body: HttpBinRequest,
-  ): ApiResponse<HttpBinResponse> {}
+  doPostWithEncodedFormData(@RequestBody _body: HttpBinRequest): ApiResponse<HttpBinResponse> {}
 
   // do simple post with formData
   @RestApi('/anything', {
@@ -93,7 +98,5 @@ export class PublicApiDataStore {
   @RestApi('/post', {
     method: 'POST',
   })
-  doUploadFileWithStreamRequest(
-    @FileUploadBody _fileToUpload: any,
-  ): ApiResponse<HttpBinResponse> {}
+  doUploadFileWithStreamRequest(@FileUploadBody _fileToUpload: any): ApiResponse<HttpBinResponse> {}
 }

--- a/src/__tests__/PublicApiDataStore.ts
+++ b/src/__tests__/PublicApiDataStore.ts
@@ -17,11 +17,17 @@ import { HttpBinResponse, HttpBinRequest } from './types';
 export class PublicApiDataStore {
   // do simple get with query params
   @RestApi('/get')
-  doSimpleHttpBinGet(@QueryParams _queryParams: HttpBinRequest): ApiResponse<HttpBinResponse> {}
+  doGetWithQueryParams(@QueryParams _queryParams: HttpBinRequest): ApiResponse<HttpBinResponse> {}
+
+  // do simple get with absolute URL
+  // this example will use url defined here
+  // instead of appended it to the baseUrl
+  @RestApi('https://httpbin.org/get')
+  doGetWithAbsoluteUrl(): ApiResponse<HttpBinResponse> {}
 
   // do simple get with path params
   @RestApi('/anything/{messageId}')
-  doSimpleHttpBinPathParamsGet(
+  doGetWithPathParamsAndQueryParams(
     @PathParam('messageId') _targetMessageId: string,
     @QueryParams _queryParams: HttpBinRequest,
   ): ApiResponse<HttpBinResponse> {}
@@ -31,14 +37,14 @@ export class PublicApiDataStore {
   @RestApi('/delay/10', {
     timeout: 3000,
   })
-  doSimpleTimeoutAPI(): ApiResponse<HttpBinResponse> {}
+  doGetWithTimeout(): ApiResponse<HttpBinResponse> {}
 
   // this API will always return 405 error
   @RestApi('/status/405')
-  doSimpleErroneousAPI(): ApiResponse<HttpBinResponse> {}
+  doErroneousAPI(): ApiResponse<HttpBinResponse> {}
 
   @RestApi('/{encodingToUse}')
-  doSimpleHttpGetWithEncoding(
+  doGetWithResponseEncoding(
     @PathParam('encodingToUse') _encoding: 'brotli' | 'gzip' | 'deflate',
   ): ApiResponse<HttpBinResponse> {}
 
@@ -47,13 +53,13 @@ export class PublicApiDataStore {
       Accept: 'application/xml',
     },
   })
-  doSimpleHttpGetWithXmlData(): ApiResponse<HttpBinResponse> {}
+  doGetWithXmlResponse(): ApiResponse<HttpBinResponse> {}
 
   // do simple post with JSON request body
   @RestApi('/post', {
     method: 'POST',
   })
-  doSimpleHttpBinPostJsonBody(@RequestBody _body: HttpBinRequest): ApiResponse<HttpBinResponse> {}
+  doPostWithJsonBody(@RequestBody _body: HttpBinRequest): ApiResponse<HttpBinResponse> {}
 
   // do simple post with URL encoded form request body
   @RestApi('/post', {
@@ -62,7 +68,7 @@ export class PublicApiDataStore {
       'Content-Type': 'application/x-www-form-urlencoded',
     },
   })
-  doSimpleHttpBinPostEncodedForm(
+  doPostWithEncodedFormData(
     @RequestBody _body: HttpBinRequest,
   ): ApiResponse<HttpBinResponse> {}
 
@@ -70,7 +76,7 @@ export class PublicApiDataStore {
   @RestApi('/anything', {
     method: 'POST',
   })
-  doSimpleFormDataHttpBinPost(
+  doPostWithFormBodyData(
     @FormDataBody('unitPrice') _unitPrice: number,
     @FormDataBody('quantity') _qty: number,
   ): ApiResponse<HttpBinResponse> {}
@@ -79,7 +85,7 @@ export class PublicApiDataStore {
   @RestApi('/anything', {
     method: 'POST',
   })
-  doSimpleUploadFileHttpBinPost(
+  doUploadFileWithFormBodyData(
     @FormDataBody('mySms') _mySmsContent: HttpBinRequest,
   ): ApiResponse<HttpBinResponse> {}
 
@@ -87,7 +93,7 @@ export class PublicApiDataStore {
   @RestApi('/post', {
     method: 'POST',
   })
-  doSimpleUploadFileWithStreamHttpBinPost(
+  doUploadFileWithStreamRequest(
     @FileUploadBody _fileToUpload: any,
   ): ApiResponse<HttpBinResponse> {}
 }

--- a/src/__tests__/RetryDataStore.spec.ts
+++ b/src/__tests__/RetryDataStore.spec.ts
@@ -5,7 +5,7 @@ const myApiInstance = new RetryDataStore();
 // NOTE: this test can only be run against the custom server which we have here in this repo.
 // to run this test, start that Node server and remove the `skip` to re-run the test
 describe.skip('RetryDataStore', () => {
-  it('Simple API Retry with fixed delay should work', () => {
+  it('API Retry with fixed delay should work', () => {
     const apiResponse = myApiInstance.doApiWithFixedRetryAfter();
 
     expect(apiResponse).toBeDefined();
@@ -20,7 +20,7 @@ describe.skip('RetryDataStore', () => {
     }
   });
 
-  it('Simple API Retry that respects server `Retry-After` response header should work', () => {
+  it('API Retry that respects server `Retry-After` response header should work', () => {
     const apiResponse = myApiInstance.doApiWithRetryAfterAsSeconds();
 
     expect(apiResponse).toBeDefined();

--- a/src/__tests__/TransformationApiDataStore.spec.ts
+++ b/src/__tests__/TransformationApiDataStore.spec.ts
@@ -1,10 +1,10 @@
 import { TransformationApiDataStore } from './TransformationApiDataStore';
 
-const myTransformationApiDataStoreInstance = new TransformationApiDataStore();
+const myApiInstance = new TransformationApiDataStore();
 
 describe('TransformationApiDataStore', () => {
-  it('Simple Request Transformation API should work - transform before request is sent', () => {
-    const apiResponse = myTransformationApiDataStoreInstance.doSimpleRequestTransformApi({
+  it('Request Transformation API should work - transform before request is sent', () => {
+    const apiResponse = myApiInstance.doRequestTransformApi({
       a: 1,
       b: 2,
     });
@@ -21,8 +21,8 @@ describe('TransformationApiDataStore', () => {
     }
   });
 
-  it('Simple Request Transformation API should work - transform before response is returned', () => {
-    const apiResponse = myTransformationApiDataStoreInstance.doSimpleResponseTransformApi({
+  it('Request Transformation API should work - transform before response is returned', () => {
+    const apiResponse = myApiInstance.doResponseTransformApi({
       a: 300,
       b: 700,
     });
@@ -38,8 +38,8 @@ describe('TransformationApiDataStore', () => {
     }
   });
 
-  it('Simple Request Transformation API should work - complex API transform before response is returned', () => {
-    const apiResponse = myTransformationApiDataStoreInstance.doComplexRequestTransformation({
+  it('Request Transformation API should work - complex API transform before response is returned', () => {
+    const apiResponse = myApiInstance.doComplexRequestTransformation({
       a: 100,
       b: 200,
       c: 300,

--- a/src/__tests__/TransformationApiDataStore.ts
+++ b/src/__tests__/TransformationApiDataStore.ts
@@ -49,9 +49,7 @@ export class TransformationApiDataStore {
       });
     },
   })
-  doSimpleRequestTransformApi(
-    @RequestBody _requestBody: NumberPair,
-  ): ApiResponse<HttpBinResponse> {}
+  doRequestTransformApi(@RequestBody _requestBody: NumberPair): ApiResponse<HttpBinResponse> {}
 
   // this example will make the api response to the backend
   // then transform the returned data by adding the 2 numbers a and b
@@ -71,7 +69,7 @@ export class TransformationApiDataStore {
       });
     },
   })
-  doSimpleResponseTransformApi(@RequestBody _requestBody: NumberPair): ApiResponse<CollectionSum> {}
+  doResponseTransformApi(@RequestBody _requestBody: NumberPair): ApiResponse<CollectionSum> {}
 
   // this example will attempt making 2 async calls for 2 sums and then add them up
   // in the request body before sending them out to the backend
@@ -85,8 +83,8 @@ export class TransformationApiDataStore {
       if (instance) {
         const { a, b, c, d } = fourNumbers;
 
-        const apiResponseSum1 = instance.doSimpleResponseTransformApi({ a: a, b: b });
-        const apiResponseSum2 = instance.doSimpleResponseTransformApi({ a: c, b: d });
+        const apiResponseSum1 = instance.doResponseTransformApi({ a: a, b: b });
+        const apiResponseSum2 = instance.doResponseTransformApi({ a: c, b: d });
 
         if (!apiResponseSum1 || !apiResponseSum2) {
           throw 'One of the request for sum failed';

--- a/src/__tests__/__snapshots__/PublicApiDataStore.spec.ts.snap
+++ b/src/__tests__/__snapshots__/PublicApiDataStore.spec.ts.snap
@@ -5,6 +5,12 @@ exports[`PublicApiDataStore POST to upload binary file using a single stream sho
 "
 `;
 
+exports[`PublicApiDataStore Simple Plain Text Response should work 1`] = `
+"User-agent: *
+Disallow: /deny
+"
+`;
+
 exports[`PublicApiDataStore Simple XML Response should work 1`] = `
 Object {
   "slideshow": Object {

--- a/src/__tests__/__snapshots__/PublicApiDataStore.spec.ts.snap
+++ b/src/__tests__/__snapshots__/PublicApiDataStore.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PublicApiDataStore Simple Public HTTP POST to upload binary file using a single stream should work 1`] = `
+exports[`PublicApiDataStore POST to upload binary file using a single stream should work 1`] = `
 "Hello world, this is a test. 123. ping. pong
 "
 `;


### PR DESCRIPTION
- [X] Allow usage of `@PathParams` on `baseUrl`, and supports that `@PathParams` for Class Members and Method Params
- [X] Allow absolute url in the `@RestApi`
- [X] Added code coverage for the jest runner
- [X] Clean up bundled/packaged modules
- [X] *chores* clean up the variable names