### PR TITLE
Added Support for single value in `@RequestProperty` and `@QueryParamProperty`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ Another inspiration is to create a unified Rest Client library that works across
 
 - [x] Supports for path params. `@PathParam` can be used in a class member or a method parameter. See usages for `@PathParam`. Refer to [Using @PathParams Section](#simple-get-rest-calls-with-path-param) for more details.
 - [x] Supports for query string. See usages for `@QueryParams` (as a hash) or `@QueryParam` (as a single query param). Refer to [Using @QueryParams and @QueryParam Section](#simple-get-rest-calls-with-query-string) for more details.
-- [x] Supports for POSTING JSON requests. See usages for `@RequestBody`. Refer to [Using @RequestBody Section](#simple-post-rest-calls-with-json-body) for more details.
+- [x] Supports for POSTING JSON requests. See usages for `@RequestBody` (as a hash). Refer to [Using @RequestBody Section](#simple-post-rest-calls-with-json-body) for more details.
 - [x] Supports POST raw data to API with `@FormDataBody`. Refer to [Using @FormData Section](#simple-post-rest-calls-with-formdata-body) for more details.
 - [x] Supports File Upload. See usages for `@FileUploadBody`. Refer to [Using @FileUploadBody Section](#simple-post-rest-calls-with-file-upload-as-stream) for more details.
 - [x] Supports JSON Parser for Request with `Content-Type=application/json`. Refer to [Parse JSON Request](#parse-json-request) for more details.
 - [x] Supports URL Encoded Form Parser for POST Request with `Content-Type=application/x-www-form-urlencoded`. Refer to [Parse URL Encoded Form Request](#parse-url-encoded-form-request) for more details.
-- [x] Supports XML Parser for Response with `Accept=application/xml`. refer to [parse XML response section](#parse-response-as-xml) for more information.
-- [x] Supports JSON Parser for Response with `Accept=application/json`. refer to [parse JSON response section](#parse-response-as-json) for more information.
+- [x] Supports XML Parser for Response with `Accept=application/xml`. refer to [Parse XML response section](#parse-response-as-xml) for more information.
+- [x] Supports JSON Parser for Response with `Accept=application/json`. refer to [Parse JSON response section](#parse-response-as-json) for more information.
 - [x] Supports for basic authorization with username and passwords. Refer to [Private Basic Auth API Section](#private-authenticated-with-username-and-password-basic-auth-api-store).
 - [x] Supports for authorization (Bearer token at the monent). Refer to [Private Bearer API Section](#private-authenticated-with-bearer-token-api-store).
 - [x] Supports custom serialization (`requestTransform`) and deserialization(`responseTransform`). Refer to [Transformation Section](#transformations) for more details
 - [x] Supports Serialization of Response Object into custom type. Refer to [Type Casting Section](#type-casting-your-response-type) for more details
 - [x] Supports for API retry config. Currently only support a fixed delay after before retry. [Max timeout for request section](#api-retries)
-- [x] Supports for API timeout config, refer to [setting max timeout for request section](#max-timeout-for-api) for more information
+- [x] Supports for API timeout config, refer to [Setting max timeout for request section](#max-timeout-for-api) for more information
 - [x] Supports abort pending API requests. Refer to [Aborting Pending Requests](#to-abort-pending-rest-calls) for more details
 - [x] Supports overrides for headers, and rest config from the `@RestClient` and `@RestApi`. Refer to [Config Overrides](#config-overrides) for more details
 
@@ -82,6 +82,7 @@ import {
   FileUploadBody,
   FormDataBody,
   PathParam,
+  QueryParam,
   QueryParams,
   RequestBody,
   RestApi,
@@ -99,6 +100,7 @@ import {
   RestApi,
   RequestBody,
   PathParam,
+  QueryParam,
   QueryParams,
   FormDataBody,
   FileUploadBody,

--- a/README.md
+++ b/README.md
@@ -2,61 +2,67 @@
 [![NPM Version](https://badge.fury.io/js/restapi-typescript-decorators.svg)](https://badge.fury.io/js/restapi-typescript-decorators)
 
 # restapi-typescript-decorators
+
 Inspired by [retrofit](https://github.com/square/retrofit) (created by Square), my goal for this project is to create a single rest client for both front end JS as well as back end node JS using just decorators (also known as annotations in the Java's world). These decorators are used to make REST API calls simpler and more declarative
 
 Another inspiration is to create a unified Rest Client library that works across the stack. In this case, to support node js and frontend code in a single code base. The goal is to create a single decorator for both node js and frontend.
 
 ### Features
-- [X] Supports for path params. `@PathParam` can be used in a class member or a method parameter. See usages for `@PathParam`. Refer to [Using @PathParams Section](#simple-get-rest-calls-with-path-param) for more details.
-- [X] Supports for query string. See usages for `@QueryParams`. Refer to [Using @QueryParams Section](#simple-get-rest-calls-with-query-string) for more details.
-- [X] Supports for POSTING JSON requests. See usages for `@RequestBody`. Refer to [Using @RequestBody Section](#simple-post-rest-calls-with-json-body) for more details.
-- [X] Supports POST raw data to API with `@FormDataBody`. Refer to [Using @FormData Section](#simple-post-rest-calls-with-formdata-body) for more details.
-- [X] Supports File Upload. See usages for `@FileUploadBody`. Refer to [Using @FileUploadBody Section](#simple-post-rest-calls-with-file-upload-as-stream) for more details.
-- [X] Supports JSON Parser for Request with `Content-Type=application/json`.  Refer to [Parse JSON Request](#parse-json-request) for more details.
-- [X] Supports URL Encoded Form Parser for POST Request with `Content-Type=application/x-www-form-urlencoded`.  Refer to [Parse URL Encoded Form Request](#parse-url-encoded-form-request) for more details.
-- [X] Supports XML Parser for Response with `Accept=application/xml`. refer to [parse XML response section](#parse-response-as-xml) for more information.
-- [X] Supports JSON Parser for Response with `Accept=application/json`. refer to [parse JSON response section](#parse-response-as-json) for more information.
-- [X] Supports for basic authorization with username and passwords. Refer to [Private Basic Auth API Section](#private-authenticated-with-username-and-password-basic-auth-api-store).
-- [X] Supports for authorization (Bearer token at the monent). Refer to [Private Bearer API Section](#private-authenticated-with-bearer-token-api-store).
-- [X] Supports custom serialization (`requestTransform`) and deserialization(`responseTransform`). Refer to [Transformation Section](#transformations) for more details
-- [X] Supports Serialization of Response Object into custom type. Refer to [Type Casting Section](#type-casting-your-response-type) for more details
-- [X] Supports for API retry config. Currently only support a fixed delay after before retry. [Max timeout for request section](#api-retries)
-- [X] Supports for API timeout config, refer to [setting max timeout for request section](#max-timeout-for-api) for more information
-- [X] Supports abort pending API requests.  Refer to [Aborting Pending Requests](#to-abort-pending-rest-calls) for more details
-- [X] Supports overrides for headers, and rest config from the `@RestClient` and `@RestApi`. Refer to [Config Overrides](#config-overrides) for more details
+
+- [x] Supports for path params. `@PathParam` can be used in a class member or a method parameter. See usages for `@PathParam`. Refer to [Using @PathParams Section](#simple-get-rest-calls-with-path-param) for more details.
+- [x] Supports for query string. See usages for `@QueryParams` (as a hash) or `@QueryParam` (as a single query param). Refer to [Using @QueryParams and @QueryParam Section](#simple-get-rest-calls-with-query-string) for more details.
+- [x] Supports for POSTING JSON requests. See usages for `@RequestBody`. Refer to [Using @RequestBody Section](#simple-post-rest-calls-with-json-body) for more details.
+- [x] Supports POST raw data to API with `@FormDataBody`. Refer to [Using @FormData Section](#simple-post-rest-calls-with-formdata-body) for more details.
+- [x] Supports File Upload. See usages for `@FileUploadBody`. Refer to [Using @FileUploadBody Section](#simple-post-rest-calls-with-file-upload-as-stream) for more details.
+- [x] Supports JSON Parser for Request with `Content-Type=application/json`. Refer to [Parse JSON Request](#parse-json-request) for more details.
+- [x] Supports URL Encoded Form Parser for POST Request with `Content-Type=application/x-www-form-urlencoded`. Refer to [Parse URL Encoded Form Request](#parse-url-encoded-form-request) for more details.
+- [x] Supports XML Parser for Response with `Accept=application/xml`. refer to [parse XML response section](#parse-response-as-xml) for more information.
+- [x] Supports JSON Parser for Response with `Accept=application/json`. refer to [parse JSON response section](#parse-response-as-json) for more information.
+- [x] Supports for basic authorization with username and passwords. Refer to [Private Basic Auth API Section](#private-authenticated-with-username-and-password-basic-auth-api-store).
+- [x] Supports for authorization (Bearer token at the monent). Refer to [Private Bearer API Section](#private-authenticated-with-bearer-token-api-store).
+- [x] Supports custom serialization (`requestTransform`) and deserialization(`responseTransform`). Refer to [Transformation Section](#transformations) for more details
+- [x] Supports Serialization of Response Object into custom type. Refer to [Type Casting Section](#type-casting-your-response-type) for more details
+- [x] Supports for API retry config. Currently only support a fixed delay after before retry. [Max timeout for request section](#api-retries)
+- [x] Supports for API timeout config, refer to [setting max timeout for request section](#max-timeout-for-api) for more information
+- [x] Supports abort pending API requests. Refer to [Aborting Pending Requests](#to-abort-pending-rest-calls) for more details
+- [x] Supports overrides for headers, and rest config from the `@RestClient` and `@RestApi`. Refer to [Config Overrides](#config-overrides) for more details
 
 ### TODO's
-- [X] Supports proper serialization of request based on headers accept
-- [X] Add a new class decorator and supports default custom properties and baseUrl at a class / repo level
-- [X] Deploy to npm modules instead of using github
-- [X] Supports to instantiate multiple classes, useful when we need to support Api with different tokens.
-- [X] Allow calling instance methods within `requestTransform` and `responseTransform`
-- [X] Added Prettier for code format
-- [X] Clean up the types and use proper types from node-fetch instead of using our own
-- [X] Integrate with CI pipeline to build stuffs and run tests automatically
-- [X] Make CI pipeline publish to npm registry
-- [X] Uses `ApiResponse` for return type instead of `any`
-- [X] Consolidate enum / string types for `HttpVerb` and `AuthType`
-- [X] Allows class level `@RestClient` override for `requesgt_transform` and `responseTransform`
-- [X] Support POST binary file to API
-- [X] Have an example repo for backend NodeJS code. Refer to the demos at [frontend example repo](https://github.com/synle/restapi-typescript-decorators-front-end-example) or [backend node js example repo](https://github.com/synle/restapi-typescript-decorators-back-end-example)
-- [X] Have an example repo for frontend code. Refer to the front end example repo
-- [X] Cleanup / Refactor and Export typescript types
-- [X] Enforce `noImplicitAny`
+
+- [x] Supports proper serialization of request based on headers accept
+- [x] Add a new class decorator and supports default custom properties and baseUrl at a class / repo level
+- [x] Deploy to npm modules instead of using github
+- [x] Supports to instantiate multiple classes, useful when we need to support Api with different tokens.
+- [x] Allow calling instance methods within `requestTransform` and `responseTransform`
+- [x] Added Prettier for code format
+- [x] Clean up the types and use proper types from node-fetch instead of using our own
+- [x] Integrate with CI pipeline to build stuffs and run tests automatically
+- [x] Make CI pipeline publish to npm registry
+- [x] Uses `ApiResponse` for return type instead of `any`
+- [x] Consolidate enum / string types for `HttpVerb` and `AuthType`
+- [x] Allows class level `@RestClient` override for `requesgt_transform` and `responseTransform`
+- [x] Support POST binary file to API
+- [x] Have an example repo for backend NodeJS code. Refer to the demos at [frontend example repo](https://github.com/synle/restapi-typescript-decorators-front-end-example) or [backend node js example repo](https://github.com/synle/restapi-typescript-decorators-back-end-example)
+- [x] Have an example repo for frontend code. Refer to the front end example repo
+- [x] Cleanup / Refactor and Export typescript types
+- [x] Enforce `noImplicitAny`
 - [ ] Throw exception when missing key params
-- [X] Make sure the retry logics respect Server side `retry-after` response header.
+- [x] Make sure the retry logics respect Server side `retry-after` response header.
 - [ ] Add support for custom retry, aka has it more dynamic as a custom function...
 - [ ] Add API debounce actions
-- [X] Add support for custom `fast-xml-parser` options
-
+- [x] Add support for custom `fast-xml-parser` options
 
 ### How to use
+
 You can also checkout the sample repos that has typescript and other things setup:
+
 - [frontend with React sample code repo](https://github.com/synle/restapi-typescript-decorators-front-end-example)
 - [backend NodeJs sample code repo](https://github.com/synle/restapi-typescript-decorators-back-end-example)
 
 #### Install it
+
 install from npm
+
 ```
 npm i --save restapi-typescript-decorators@^6
 ```
@@ -64,9 +70,11 @@ npm i --save restapi-typescript-decorators@^6
 Make sure you have the typescript and decorator enabled in your `tsconfig.json`
 
 #### Simple Code Example
+
 Most of these examples return `ApiResponse<any>` for simplicity. You can use the library to cast the response object in a custom format. Refer to the bottom section of this guide for how to do type cast your requests and responses.
 
 #### import the classes
+
 ```
 import {
   ApiResponse,
@@ -82,7 +90,9 @@ import {
 ```
 
 #### Public (non authenticated) API Store
+
 Below is an example on the definition for public API data store.
+
 ```
 import {
   RestClient,
@@ -127,39 +137,93 @@ export interface HttpBinResponse {
   baseUrl: 'https://httpbin.org',
 })
 export class PublicApiDataStore {
-  // do simple get with query params
-  @RestApi('/get')
-  doGetWithQueryParams(@QueryParams _queryParams: HttpBinRequest): ApiResponse<HttpBinResponse> {}
-
-  // do simple get with absolute URL
-  // this example will use url defined here
-  // instead of appended it to the baseUrl
+  /**
+   * do get with absolute URL. This example will use
+   * url defined here instead of appended it to the baseUrl
+   */
   @RestApi('https://httpbin.org/get')
   doGetWithAbsoluteUrl(): ApiResponse<HttpBinResponse> {}
 
-  // do simple get with path params
+  /**
+   * do get with query params (as a hash of queryParamKey => queryParamValue)
+   * @param _queryParams
+   */
+  @RestApi('/get')
+  doGetWithQueryParams(@QueryParams _queryParams: HttpBinRequest): ApiResponse<HttpBinResponse> {}
+
+  /**
+   * do get with query params (as a single parameter). This example will construct url as
+   * /get?keyword=<_keyword>&_pageSize=<number>
+   * @param _keyword
+   * @param _pageSize
+   */
+  @RestApi('/get')
+  doGetWithSingleQueryParam(
+    @QueryParam('keyword') _keyword: string = '',
+    @QueryParam('pageSize') _pageSize: number = 100,
+  ): ApiResponse<HttpBinResponse> {}
+
+  /**
+   * do get with a combination of both single query param, and query params hash. In this
+   * example, we will combine the two query params with single query param has higher
+   * precedence than query params hash
+   * @param _query
+   * @param _pageSize
+   */
+  @RestApi('/get')
+  doGetWithQueryParamsCombo(
+    @QueryParams _query: HttpBinRequest,
+    @QueryParam('pageSize') _pageSize: number = 100,
+  ): ApiResponse<HttpBinResponse> {}
+
+  /**
+   * do get with a path param which will replace
+   * `{recordId}` fragment in the URL with value you invoke the method with
+   * @param _recordId value to replace {recordId} URL fragment
+   */
+  @RestApi('/anything/{recordId}')
+  doGetWithPathParams(@PathParam('recordId') _recordId: string): ApiResponse<HttpBinResponse> {}
+
+  /**
+   * do get with path params and query params
+   * @param _messageId value to replace {messageId} URL fragment
+   * @param _queryParams query params
+   */
   @RestApi('/anything/{messageId}')
   doGetWithPathParamsAndQueryParams(
-    @PathParam('messageId') _targetMessageId: string,
+    @PathParam('messageId') _messageId: string,
     @QueryParams _queryParams: HttpBinRequest,
   ): ApiResponse<HttpBinResponse> {}
 
-  // the actual API will return in 10 seconds, but the client
-  // will fail and timeout in 3 seconds
+  /**
+   * do get with a timeout. The REST call will be aborted after
+   * 3 seconds.
+   */
   @RestApi('/delay/10', {
     timeout: 3000,
   })
   doGetWithTimeout(): ApiResponse<HttpBinResponse> {}
 
-  // this API will always return 405 error
+  /**
+   * do get with an Erroneous API. The backend of this API will
+   * always return 405 error
+   */
   @RestApi('/status/405')
   doErroneousAPI(): ApiResponse<HttpBinResponse> {}
 
+  /**
+   * do get with custom encoding from the backend API.
+   * @param _encoding
+   */
   @RestApi('/{encodingToUse}')
   doGetWithResponseEncoding(
     @PathParam('encodingToUse') _encoding: 'brotli' | 'gzip' | 'deflate',
   ): ApiResponse<HttpBinResponse> {}
 
+  /**
+   * do get with XML Response. This method will parse the XML responses into
+   * JSON objects
+   */
   @RestApi('/xml', {
     headers: {
       Accept: 'application/xml',
@@ -167,24 +231,43 @@ export class PublicApiDataStore {
   })
   doGetWithXmlResponse(): ApiResponse<HttpBinResponse> {}
 
-  // do simple post with JSON request body
+  /**
+   * do get call with Plain Text Response. This method will simply return the
+   * Plain Text response from the back end API.
+   */
+  @RestApi('/robots.txt', {
+    headers: {
+      Accept: 'text/plain',
+    },
+  })
+  doGetWithPlainTextResponse(): ApiResponse<string> {}
+
+  /**
+   * do post with JSON request body
+   * @param _body
+   */
   @RestApi('/post', {
     method: 'POST',
   })
   doPostWithJsonBody(@RequestBody _body: HttpBinRequest): ApiResponse<HttpBinResponse> {}
 
-  // do simple post with URL encoded form request body
+  /**
+   * do post with URL encoded form request body
+   * @param _body
+   */
   @RestApi('/post', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
     },
   })
-  doPostWithEncodedFormData(
-    @RequestBody _body: HttpBinRequest,
-  ): ApiResponse<HttpBinResponse> {}
+  doPostWithEncodedFormData(@RequestBody _body: HttpBinRequest): ApiResponse<HttpBinResponse> {}
 
-  // do simple post with formData
+  /**
+   * do post with formData
+   * @param _unitPrice
+   * @param _qty
+   */
   @RestApi('/anything', {
     method: 'POST',
   })
@@ -193,7 +276,10 @@ export class PublicApiDataStore {
     @FormDataBody('quantity') _qty: number,
   ): ApiResponse<HttpBinResponse> {}
 
-  // this example uploads the file via input named `mySms`
+  /**
+   * do post to upload the file via input named `mySms` with formData
+   * @param _mySmsContent
+   */
   @RestApi('/anything', {
     method: 'POST',
   })
@@ -201,23 +287,26 @@ export class PublicApiDataStore {
     @FormDataBody('mySms') _mySmsContent: HttpBinRequest,
   ): ApiResponse<HttpBinResponse> {}
 
-  // this example uploads the file as a single stream
+  /**
+   * do post to upload the file as a single stream
+   * @param _fileToUpload
+   */
   @RestApi('/post', {
     method: 'POST',
   })
-  doUploadFileWithStreamRequest(
-    @FileUploadBody _fileToUpload: any,
-  ): ApiResponse<HttpBinResponse> {}
+  doUploadFileWithStreamRequest(@FileUploadBody _fileToUpload: any): ApiResponse<HttpBinResponse> {}
 }
 ```
 
 **Then instantiate it as**
+
 ```
 import { PublicApiDataStore } from './PublicApiDataStore';
 const myApiInstance = new PublicApiDataStore();
 ```
 
 **Use it**
+
 ```
 apiResponse = myApiInstance.doGetWithQueryParams({a: 1, b: 2});
 if(apiResponse){
@@ -229,9 +318,10 @@ if(apiResponse){
 }
 ```
 
-
 #### Private (authenticated with Bearer Token) API Store
+
 Below is an example on the definition for private API data store.
+
 ```
 import {
   RestClient,
@@ -274,6 +364,7 @@ export class PrivateBearerAuthApiDataStore {
 ```
 
 **Then instantiate it as**
+
 ```
 import { PrivateBearerAuthApiDataStore } from './PrivateBearerAuthApiDataStore';
 const myApiInstance = new PrivateBearerAuthApiDataStore(
@@ -284,9 +375,8 @@ const myApiInstance = new PrivateBearerAuthApiDataStore(
 // ... refer to other section for how to execute the calls
 ```
 
-
-
 #### Private (authenticated with username and password basic auth) API Store
+
 ```
 import {
   RestClient,
@@ -333,6 +423,7 @@ export class PrivateBasicAuthApiDataStore {
 ```
 
 **Then instantiate it as**
+
 ```
 import { PrivateBasicAuthApiDataStore } from './PrivateBasicAuthApiDataStore';
 const myApiInstance = new PrivateBasicAuthApiDataStore(
@@ -343,8 +434,8 @@ const myApiInstance = new PrivateBasicAuthApiDataStore(
 // ... refer to other section for how to execute the calls
 ```
 
-
 #### To execute the RestClient
+
 ```
 const myApiInstance = new PrivateApiDataStore('<<some_strong_and_random_access_token>>');
 
@@ -362,6 +453,7 @@ if(apiResponse){
 ```
 
 #### To abort pending Rest calls
+
 Sometimes you want to abort a pending Rest call. You can use `apiResponse.abort()`. Note that this action will also disable any attempt to retry the API for any pending instance method invokation. Say you are calling a fetch user with 5 retries, if you do `abort`. At that moment in time, the API will stop the pending API call and any retry.
 
 ```
@@ -379,16 +471,44 @@ if(apiResponse){
 ```
 
 #### Simple GET REST Calls with Query String
-This will send a GET request to the backend with query string attached. The library will handle url encoding for your data. So no need to encode it when using this API.
+
+You can use either `@QueryParams` (as a hash) or `QueryParam` (as a single value for query string). This will send a GET request to the backend with query string attached. The library will handle url encoding for your data. So no need to encode it when using this API.
+
+If you do have a mixture of `@QueryParams` and `@QueryParam` in your method decorators. The final query string will be merged with single value `@QueryParam` having higher precedence than `@QueryParams` hash
+
+This example will pass a hash (queryStringKey => queryStringValue) into the query string
+
 ```
+/**
+  * do get with query params (as a hash of queryParamKey => queryParamValue)
+  * @param _queryParams
+  */
 @RestApi('/get')
 doGetWithQueryParams(@QueryParams _queryParams: HttpBinRequest): ApiResponse<HttpBinResponse> {}
 ```
 
+This example will pass a single value into the query string
+
+```
+/**
+  * do get with query params (as a single parameter). This example will construct url as
+  * /get?keyword=<_keyword>&_pageSize=<number>
+  * @param _keyword
+  * @param _pageSize
+  */
+@RestApi('/get')
+doGetWithSingleQueryParam(
+  @QueryParam('keyword') _keyword: string = '',
+  @QueryParam('pageSize') _pageSize: number = 100,
+): ApiResponse<HttpBinResponse> {}
+```
+
 #### Simple GET REST Calls with Path Param
+
 @PathParams can be used in a class members (class attributes) or method parameters.
 
 Below is an example of how path params can be used in a class member
+
 ```
 @RestApi("/anything/{messageId}")
 doGetWithPathParams(
@@ -397,6 +517,7 @@ doGetWithPathParams(
 ```
 
 The following code shows how path params can be used in class members and method parameters
+
 ```
 @RestClient({
   baseUrl: 'https://httpbin.org/cookies/set/{cookieName}/{cookieValue}',
@@ -415,6 +536,7 @@ export class PathParamApiDataStore {
 ```
 
 #### Simple GET REST Calls with Path Param and Query String
+
 ```
 @RestApi('/anything/{messageId}')
 doGetWithPathParamsAndQueryParams(
@@ -424,6 +546,7 @@ doGetWithPathParamsAndQueryParams(
 ```
 
 #### Simple POST Rest Calls with JSON Body
+
 ```
 @RestApi('/post', {
   method: 'POST',
@@ -431,8 +554,8 @@ doGetWithPathParamsAndQueryParams(
 doPostWithJsonBody(@RequestBody _body: HttpBinRequest): ApiResponse<HttpBinResponse> {}
 ```
 
-
 #### Simple POST Rest Calls with FormData Body
+
 ```
 @RestApi('/anything', {
   method: 'POST',
@@ -443,8 +566,8 @@ doPostWithFormBodyData(
 ): ApiResponse<HttpBinResponse> {}
 ```
 
-
 #### Simple POST Rest Calls with File Upload as Stream
+
 This example uploads the file as a single stream
 
 ```
@@ -460,6 +583,7 @@ doSimpleUploadFileWithStreamHttpBinPost(
 ```
 
 This expects your response to be a buffer. Below is how you can craft the buffer for Node Js
+
 ```
 import fs from 'fs';
 const sampleSmsFileStream = fs.createReadStream('SampleSms.txt');
@@ -469,22 +593,27 @@ const apiResponse = myPublicDataStoreInstance.doSimpleUploadFileWithStreamHttpBi
 ```
 
 #### URL Notes
+
 By default, the library will construct the url to use as:
 
 - When `@RestApi.url` is a relative url (for example "`/myAPI`"). The url by appended the `url` from `@RestApi` to `baseUrl` from `@RestClient` as:
+
 ```
 urlToUse = @RestClient.baseUrl + @RestApi.url
 ```
 
 - When `@RestApi.url` is an absolute url which starts with `http://` or `https://` (for example "`https://httpbin.org/get`" or "`http://httpbin.org/get`"). That absolute url will be used and won't be appended to the `baseUrl`
+
 ```
 urlToUse = @RestApi.url
 ```
 
 #### Type casting your response type
+
 Sometimes it might be useful to cast / parsing the json object in the response to match certain object type. We can do so with this library using this approach.
 
 **Then RestClient class will look something like this**
+
 ```
 import {
   RestClient,
@@ -522,9 +651,11 @@ export class TypeCastApiDataStore {
 ```
 
 #### Max timeout for API
+
 You can set a max timeout using the `timeout` attribute. In which the API will be aborted if the timeout has passed.
 
 In this example, the actual API will return in 10 seconds, but the client will timeout and abort the request in 3 seconds
+
 ```
 @RestApi('/delay/10', {
   timeout: 3000,
@@ -533,15 +664,18 @@ doSimpleTimeoutAPI(): ApiResponse<HttpBinResponse> {}
 ```
 
 #### API Retries
-For cases when API can fail due to some QPS (Query Per Second) requirements and the vendor wants the user to attempt a retry at a later time, you can set the parameter for retryConfigs which allows the API to be retried. This way the API will be called again until the totalRetry has passed. To use this, simply set the `retryConfigs` under the `@RestApi`  decorator.
+
+For cases when API can fail due to some QPS (Query Per Second) requirements and the vendor wants the user to attempt a retry at a later time, you can set the parameter for retryConfigs which allows the API to be retried. This way the API will be called again until the totalRetry has passed. To use this, simply set the `retryConfigs` under the `@RestApi` decorator.
 
 This example below will retry if there's failure in the response. It will wait a second before attempting a new retry.
 
 As for checking how many retries has been attempted to reach the API. You can refer to the `retryCount` property of the `ApiResponse`.
 
 Note:
+
 - That when the user attempted to abort the API calls manually using the `abort()` method from `ApiResponse`, this action will stop the API from further retries.
 - Another note is that the client will respect server `Retry-After` response header. And will attempt to retry after that delay. At the moment we only support `Retry-After` that is of number of seconds to invoke an API retry
+
 ```
 @RestClient({
   baseUrl: 'http://localhost:8080',
@@ -557,19 +691,20 @@ export class RetryDataStore {
 }
 ```
 
-
 #### Understanding the ApiResponse.result Promise
+
 It's the promise that wrapped around the fetch calls. At the moment, the API will return the resolved promise state when the API is successful, and rejected state if the call is aborted by the user or it's an API network error.
 
-
 #### Request and Response Format
+
 By default, the library will help parsing of the response when you set the proper value for `Accept` Header.
 
 To use the default parser, you can set the Accept Header. This example below will tell the library to parse the response as if the response is a XML. The default behavior is to parse response as JSON.
 
-
 ##### Parse JSON Request
+
 The default header value for `Content-Type` is `application/json`. You can also be explicit about it. But basically it will transform your JSON request object into JSON string understood by the backend that consumes JSON.
+
 ```
 @RestApi('/post', {
   method: 'POST',
@@ -581,9 +716,10 @@ The default header value for `Content-Type` is `application/json`. You can also 
 doSimpleHttpBinPostJsonBody(@RequestBody _body: HttpBinRequest): ApiResponse<HttpBinResponse> {}
 ```
 
-
 ##### Parse URL Encoded Form Request
+
 The default header value for `Content-Type` is `application/x-www-form-urlencoded`. When this is provided, the library will send your request in url encoded form format.
+
 ```
 @RestApi('/post', {
   method: 'POST',
@@ -596,10 +732,10 @@ doSimpleHttpBinPostEncodedForm(
 ): ApiResponse<HttpBinResponse> {}
 ```
 
-
-
 ##### Parse Response as XML
+
 This will parse the XML response and return them as JSON object
+
 ```
 @RestApi('/xml', {
 // the following header value is implied
@@ -611,7 +747,9 @@ doSimpleHttpGetWithXmlData(): ApiResponse<HttpBinResponse> {}
 ```
 
 ##### Parse Response as JSON
+
 The default header value for `Accept` is `application/json`. You can also be explicit about it. But basically it will transform your response into JSON objects.
+
 ```
 @RestApi('/json', {
   headers: {
@@ -621,8 +759,8 @@ The default header value for `Accept` is `application/json`. You can also be exp
 doSimpleJSONGet(): ApiResponse<HttpBinResponse> {}
 ```
 
-
 You can also provide `fast-xml-parser` custom configurations for the client using `@RestClient` property `xmlParseOptions` at the class level.
+
 ```
 
 @RestClient({
@@ -647,11 +785,12 @@ export class TransformationApiDataStore {
 ```
 
 #### Transformations
+
 You can use `requestTransform` and `responseTransform` to do transformation on the request and response API. You can define the transformation at both the `@RestClient` or `@RestApi` level. When both are defined, a more specific tranformation at `@RestApi` will be used toward the final transformation.
 
 #### Simple request transform
-This example will transform the request before sending the request to the backend. The example will do some translation to the input data before sending the data to the backend.
 
+This example will transform the request before sending the request to the backend. The example will do some translation to the input data before sending the data to the backend.
 
 ```
 import {
@@ -701,11 +840,9 @@ if(apiResponse){
 }
 ```
 
-
-
 #### Simple response transform
-This example will transform the response before returning the final result to the front end. The example code will add the response values and return the sum as the response
 
+This example will transform the response before returning the final result to the front end. The example code will add the response values and return the sum as the response
 
 ```
 import {
@@ -751,13 +888,14 @@ if(apiResponse){
 }
 ```
 
-
 #### Config Overrides
+
 We have 3 layers of configs: `DefaultConfig` (default configs from this library), `@RestClient` Custom Configs and `@RestApi` Custom Configs. The final config values are set using this order `DefaultConfig`, `@RestClient`, and `@RestApi`.
 
 #### Config Override Table
+
 | `DefaultConfigs` | `@RestClient` | `@RestApi` | `Config To Use` |
-|------------------|---------------|------------|-----------------|
+| ---------------- | ------------- | ---------- | --------------- |
 | a                | b             | c          | c               |
 | a                | b             |            | b               |
 | a                |               | c          | c               |
@@ -767,7 +905,9 @@ We have 3 layers of configs: `DefaultConfig` (default configs from this library)
 |                  |               | c          | c               |
 
 #### Config Override Example
+
 Below is an example on how to set Custom Config
+
 ```
 import {
   RestClient,
@@ -808,26 +948,30 @@ export class OverrideConfigApiDataStore {
 ```
 
 With the above example
+
 - `--Rest-Api-Custom-Header`: will be `<some_value_@RestApi_222>` because it's set in @RestApi which has more specificity even though its value in `@RestClient` is `<this_value_will_overrided>`
 - `--Rest-Client-Custom-Header`: will be `<some_value_@Restclient_111>` because it's set inside of `@RestApi` although it's not defined anywhere else in `DefaultConfigs` or `@RestClient`
 - `Content-Type`: will be `application/json` because it's set in the `DefaultConfigs` even though we didn't specify it.
 
-
-
 #### Notes
+
 - For POST method and POST JSON body of `appplication/json`, the request will stringify and properly saves it into the body
 - Note that when both `@RequestBody` and `@FormDataBody` are used, `@FormDataBody` will have higher precendence
 
 ### How to contribute?
+
 Make the change and create PR against master.
 
 ### Issues?
+
 If you have any issue with the API, feel free to file a bug on Github at https://github.com/synle/restapi-typescript-decorators/issues/new
 
 #### Note on release pipeline
+
 To publish directly to npm
 
 ##### Beta Tags
+
 ```
 npm run build && \
 npm version prepatch && \
@@ -835,6 +979,7 @@ npm publish --tag beta
 ```
 
 ##### Prod Tags
+
 ```
 npm run build && \
 npm version patch && \

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   setupFilesAfterEnv: ['./jest.setup.js'],
   moduleNameMapper: {
-    "restapi-typescript-decorators": "<rootDir>/src/index",
+    'restapi-typescript-decorators': '<rootDir>/src/index',
   },
   collectCoverage: true,
 };

--- a/mock-server/README.md
+++ b/mock-server/README.md
@@ -1,1 +1,0 @@
-The mock server has been moved to the back end example repo. Please check this link: https://github.com/synle/restapi-typescript-decorators-back-end-example

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "restapi-typescript-decorators",
-  "version": "6.0.7",
+  "version": "6.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "build/index.d.ts",
   "scripts": {
     "build": "rm -rf build/* && tsc",
-    "format": "prettier --config ./.prettierrc --write src/**/**/**/**/*.{ts,tsx,js,jsx,scss} mock-server/**/**/*.js *.{json,MD} README.md",
+    "format": "prettier --config ./.prettierrc --write src/**/**/**/**/*.{ts,tsx,js,jsx,scss} mock-server/**/**/*.js *.json *.js .prettierrc *.md ",
     "clean": "jest --clearCache && rm -rf build/*",
     "test": "jest --ci",
     "test:resetSnapshot": "jest --ci --updateSnapshot"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "build/index.d.ts",
   "scripts": {
     "build": "rm -rf build/* && tsc",
-    "format": "prettier --config ./.prettierrc --write src/**/**/**/**/*.{ts,tsx,js,jsx,scss} mock-server/**/**/*.js *.{json,MD}",
+    "format": "prettier --config ./.prettierrc --write src/**/**/**/**/*.{ts,tsx,js,jsx,scss} mock-server/**/**/*.js *.{json,MD} README.md",
     "clean": "jest --clearCache && rm -rf build/*",
     "test": "jest --ci",
     "test:resetSnapshot": "jest --ci --updateSnapshot"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restapi-typescript-decorators",
-  "version": "6.0.7",
+  "version": "6.0.8",
   "description": "Decorators that helps reduce the boilderplate code for rest api calls on the frontend and node js",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/__tests__/OverrideConfigApiDataStore.ts
+++ b/src/__tests__/OverrideConfigApiDataStore.ts
@@ -1,12 +1,4 @@
-import {
-  RestClient,
-  RestApi,
-  RequestBody,
-  PathParam,
-  QueryParams,
-  FormDataBody,
-  ApiResponse,
-} from 'restapi-typescript-decorators';
+import { RestClient, RestApi, ApiResponse } from 'restapi-typescript-decorators';
 
 import { HttpBinResponse, HttpBinRequest } from './types';
 

--- a/src/__tests__/OverrideTransformDataStore.ts
+++ b/src/__tests__/OverrideTransformDataStore.ts
@@ -2,9 +2,7 @@ import {
   RestClient,
   RestApi,
   RequestBody,
-  PathParam,
   QueryParams,
-  FormDataBody,
   ApiResponse,
 } from 'restapi-typescript-decorators';
 

--- a/src/__tests__/PathParamApiDataStore.ts
+++ b/src/__tests__/PathParamApiDataStore.ts
@@ -1,12 +1,4 @@
-import {
-  RestClient,
-  RestApi,
-  RequestBody,
-  PathParam,
-  QueryParams,
-  FormDataBody,
-  ApiResponse,
-} from 'restapi-typescript-decorators';
+import { RestClient, RestApi, PathParam, ApiResponse } from 'restapi-typescript-decorators';
 
 import { HttpBinResponse, HttpBinRequest } from './types';
 

--- a/src/__tests__/PrivateBasicAuthApiDataStore.ts
+++ b/src/__tests__/PrivateBasicAuthApiDataStore.ts
@@ -2,10 +2,6 @@ import {
   RestClient,
   RestApi,
   CredentialProperty,
-  RequestBody,
-  PathParam,
-  QueryParams,
-  FormDataBody,
   ApiResponse,
 } from 'restapi-typescript-decorators';
 

--- a/src/__tests__/PrivateBearerAuthApiDataStore.ts
+++ b/src/__tests__/PrivateBearerAuthApiDataStore.ts
@@ -2,10 +2,6 @@ import {
   RestClient,
   RestApi,
   CredentialProperty,
-  RequestBody,
-  PathParam,
-  QueryParams,
-  FormDataBody,
   ApiResponse,
 } from 'restapi-typescript-decorators';
 

--- a/src/__tests__/PublicApiDataStore.spec.ts
+++ b/src/__tests__/PublicApiDataStore.spec.ts
@@ -117,8 +117,8 @@ describe('PublicApiDataStore', () => {
     }
   });
 
-  it('POST with JSON @RequestBody should work', () => {
-    const apiResponse = myApiInstance.doPostWithJsonBody({ a: 1, b: 2, c: 3 });
+  it('POST with JSON @RequestBody (as a hash) should work', () => {
+    const apiResponse = myApiInstance.doPostWithJsonBodyHash({ a: 1, b: 2, c: 3 });
 
     expect(apiResponse).toBeDefined();
 
@@ -127,6 +127,49 @@ describe('PublicApiDataStore', () => {
         expect(apiResponse.ok).toBe(true);
         expect(apiResponse.status).toBe(200);
         expect(resp.json).toEqual({ a: 1, b: 2, c: 3 });
+        expect(resp.url).toEqual('https://httpbin.org/post');
+      });
+    }
+  });
+
+  it('POST with JSON @RequestProperty (as a single value) should work', () => {
+    const apiResponse = myApiInstance.doPostWithSingleValuesJsonBody(
+      'Sy', // first name
+      'Le', // last name
+    );
+
+    expect(apiResponse).toBeDefined();
+
+    if (apiResponse) {
+      return apiResponse.result.then((resp) => {
+        expect(apiResponse.ok).toBe(true);
+        expect(apiResponse.status).toBe(200);
+        expect(resp.json).toEqual({ firstName: 'Sy', lastName: 'Le' });
+        expect(resp.url).toEqual('https://httpbin.org/post');
+      });
+    }
+  });
+
+  it('POST with JSON body combo of @RequestProperty (as a single value) and @RequestProperty (as a single value) should work', () => {
+    const apiResponse = myApiInstance.doPostWithJsonBodyMixture(
+      {
+        oldPassword: '123',
+        newPassword: '456',
+      },
+      '5d3fd566-a3d7-4d44-994c-a4cee8d53f63', // userId
+    );
+
+    expect(apiResponse).toBeDefined();
+
+    if (apiResponse) {
+      return apiResponse.result.then((resp) => {
+        expect(apiResponse.ok).toBe(true);
+        expect(apiResponse.status).toBe(200);
+        expect(resp.json).toEqual({
+          newPassword: '456',
+          oldPassword: '123',
+          userId: '5d3fd566-a3d7-4d44-994c-a4cee8d53f63',
+        });
         expect(resp.url).toEqual('https://httpbin.org/post');
       });
     }

--- a/src/__tests__/PublicApiDataStore.spec.ts
+++ b/src/__tests__/PublicApiDataStore.spec.ts
@@ -5,6 +5,118 @@ const myApiInstance = new PublicApiDataStore();
 const sampleTextFile = 'SampleSms.txt';
 
 describe('PublicApiDataStore', () => {
+  it('GET with absolute URL should work', () => {
+    const apiResponse = myApiInstance.doGetWithAbsoluteUrl();
+
+    expect(apiResponse).toBeDefined();
+
+    if (apiResponse) {
+      return apiResponse.result.then((resp) => {
+        expect(apiResponse.ok).toBe(true);
+        expect(apiResponse.status).toBe(200);
+        expect(resp.url).toEqual('https://httpbin.org/get');
+      });
+    }
+  });
+
+  it('GET with query params should work', () => {
+    const apiResponse = myApiInstance.doGetWithQueryParams({ a: 1, b: 2, c: 3 });
+
+    expect(apiResponse).toBeDefined();
+
+    if (apiResponse) {
+      return apiResponse.result.then((resp) => {
+        expect(apiResponse.ok).toBe(true);
+        expect(apiResponse.status).toBe(200);
+        expect(resp.args).toEqual({ a: '1', b: '2', c: '3' });
+        expect(resp.url).toEqual('https://httpbin.org/get?a=1&b=2&c=3');
+      });
+    }
+  });
+
+  it('GET with path params and query params should work', () => {
+    const apiResponse = myApiInstance.doGetWithPathParamsAndQueryParams('secret_message_id_123', {
+      aa: 1,
+      bb: 2,
+      cc: 3,
+    });
+
+    expect(apiResponse).toBeDefined();
+
+    if (apiResponse) {
+      return apiResponse.result.then((resp) => {
+        expect(apiResponse.ok).toBe(true);
+        expect(apiResponse.status).toBe(200);
+        expect(resp.args).toEqual({ aa: '1', bb: '2', cc: '3' });
+        expect(resp.url).toEqual(
+          'https://httpbin.org/anything/secret_message_id_123?aa=1&bb=2&cc=3',
+        );
+      });
+    }
+  });
+
+  it('GET with single path params', () => {
+    const apiResponse = myApiInstance.doGetWithSingleQueryParam('javascript', 20);
+
+    expect(apiResponse).toBeDefined();
+
+    if (apiResponse) {
+      return apiResponse.result.then((resp) => {
+        expect(apiResponse.ok).toBe(true);
+        expect(apiResponse.status).toBe(200);
+        expect(resp.args).toEqual({ keyword: 'javascript', pageSize: '20' });
+        expect(resp.url).toContain('keyword=javascript');
+        expect(resp.url).toContain('pageSize=20');
+      });
+    }
+  });
+
+  it('GET with query params combo (hash and single value) should work', () => {
+    const apiResponse = myApiInstance.doGetWithQueryParamsCombo(
+      {
+        city: 'San Francisco',
+        radius: '< 2 miles',
+        price: '< 4000',
+      },
+      20, // page size
+    );
+
+    expect(apiResponse).toBeDefined();
+
+    if (apiResponse) {
+      return apiResponse.result.then((resp) => {
+        expect(apiResponse.ok).toBe(true);
+        expect(apiResponse.status).toBe(200);
+        expect(resp.args).toEqual({
+          city: 'San Francisco',
+          pageSize: '20',
+          price: '< 4000',
+          radius: '< 2 miles',
+        });
+        expect(resp.url).toContain('city=San Francisco');
+        expect(resp.url).toContain('radius=< 2 miles');
+        expect(resp.url).toContain('price=< 4000');
+        expect(resp.url).toContain('pageSize=20');
+      });
+    }
+  });
+
+  it('GET with path params should work', () => {
+    const apiResponse = myApiInstance.doGetWithPathParams('92a38a41-0a47-4651-8253-c329af28a723');
+
+    expect(apiResponse).toBeDefined();
+
+    if (apiResponse) {
+      return apiResponse.result.then((resp) => {
+        expect(apiResponse.ok).toBe(true);
+        expect(apiResponse.status).toBe(200);
+        expect(resp.url).toEqual(
+          'https://httpbin.org/anything/92a38a41-0a47-4651-8253-c329af28a723',
+        );
+      });
+    }
+  });
+
   it('POST with JSON @RequestBody should work', () => {
     const apiResponse = myApiInstance.doPostWithJsonBody({ a: 1, b: 2, c: 3 });
 
@@ -35,56 +147,6 @@ describe('PublicApiDataStore', () => {
         expect(apiResponse.status).toBe(200);
         expect(resp.form).toEqual({ a: '1', b: '2', c: '3' });
         expect(resp.url).toEqual('https://httpbin.org/post');
-      });
-    }
-  });
-
-  it('GET with query params should work', () => {
-    const apiResponse = myApiInstance.doGetWithQueryParams({ a: 1, b: 2, c: 3 });
-
-    expect(apiResponse).toBeDefined();
-
-    if (apiResponse) {
-      return apiResponse.result.then((resp) => {
-        expect(apiResponse.ok).toBe(true);
-        expect(apiResponse.status).toBe(200);
-        expect(resp.args).toEqual({ a: '1', b: '2', c: '3' });
-        expect(resp.url).toEqual('https://httpbin.org/get?a=1&b=2&c=3');
-      });
-    }
-  });
-
-  it('GET with absolute URL should work', () => {
-    const apiResponse = myApiInstance.doGetWithAbsoluteUrl();
-
-    expect(apiResponse).toBeDefined();
-
-    if (apiResponse) {
-      return apiResponse.result.then((resp) => {
-        expect(apiResponse.ok).toBe(true);
-        expect(apiResponse.status).toBe(200);
-        expect(resp.url).toEqual('https://httpbin.org/get');
-      });
-    }
-  });
-
-  it('GET with path params and query params should work', () => {
-    const apiResponse = myApiInstance.doGetWithPathParamsAndQueryParams('secret_message_id_123', {
-      aa: 1,
-      bb: 2,
-      cc: 3,
-    });
-
-    expect(apiResponse).toBeDefined();
-
-    if (apiResponse) {
-      return apiResponse.result.then((resp) => {
-        expect(apiResponse.ok).toBe(true);
-        expect(apiResponse.status).toBe(200);
-        expect(resp.args).toEqual({ aa: '1', bb: '2', cc: '3' });
-        expect(resp.url).toEqual(
-          'https://httpbin.org/anything/secret_message_id_123?aa=1&bb=2&cc=3',
-        );
       });
     }
   });

--- a/src/__tests__/PublicApiDataStore.ts
+++ b/src/__tests__/PublicApiDataStore.ts
@@ -1,9 +1,10 @@
 import {
   RestClient,
   RestApi,
+  RequestProperty,
   RequestBody,
   PathParam,
-  QueryParam,
+  QueryParamProperty,
   QueryParams,
   FormDataBody,
   FileUploadBody,
@@ -38,8 +39,8 @@ export class PublicApiDataStore {
    */
   @RestApi('/get')
   doGetWithSingleQueryParam(
-    @QueryParam('keyword') _keyword: string = '',
-    @QueryParam('pageSize') _pageSize: number = 100,
+    @QueryParamProperty('keyword') _keyword: string,
+    @QueryParamProperty('pageSize') _pageSize: number,
   ): ApiResponse<HttpBinResponse> {}
 
   /**
@@ -52,7 +53,7 @@ export class PublicApiDataStore {
   @RestApi('/get')
   doGetWithQueryParamsCombo(
     @QueryParams _query: HttpBinRequest,
-    @QueryParam('pageSize') _pageSize: number = 100,
+    @QueryParamProperty('pageSize') _pageSize: number,
   ): ApiResponse<HttpBinResponse> {}
 
   /**
@@ -122,13 +123,41 @@ export class PublicApiDataStore {
   doGetWithPlainTextResponse(): ApiResponse<string> {}
 
   /**
-   * do post with JSON request body
+   * do post JSON request body with  @RequestBody (as a hash)
    * @param _body
    */
   @RestApi('/post', {
     method: 'POST',
   })
-  doPostWithJsonBody(@RequestBody _body: HttpBinRequest): ApiResponse<HttpBinResponse> {}
+  doPostWithJsonBodyHash(@RequestBody _body: HttpBinRequest): ApiResponse<HttpBinResponse> {}
+
+  /**
+   * do post JSON request body with  @RequestBody (as a hash)
+   * @param _body
+   */
+  @RestApi('/post', {
+    method: 'POST',
+  })
+  doPostWithSingleValuesJsonBody(
+    @RequestProperty('firstName') _firstName: string,
+    @RequestProperty('lastName') _lastName: string,
+  ): ApiResponse<HttpBinResponse> {}
+
+  /**
+   * do post with a combination of both single request property, and request body hash. In this
+   * example, we will combine the two together with single request property has higher
+   * precedence than query params hash
+   *
+   * @param _body
+   * @param _userId
+   */
+  @RestApi('/post', {
+    method: 'POST',
+  })
+  doPostWithJsonBodyMixture(
+    @RequestBody _body: HttpBinRequest,
+    @RequestProperty('userId') _userId: string,
+  ): ApiResponse<HttpBinResponse> {}
 
   /**
    * do post with URL encoded form request body

--- a/src/__tests__/PublicApiDataStore.ts
+++ b/src/__tests__/PublicApiDataStore.ts
@@ -3,6 +3,7 @@ import {
   RestApi,
   RequestBody,
   PathParam,
+  QueryParam,
   QueryParams,
   FormDataBody,
   FileUploadBody,
@@ -15,39 +16,93 @@ import { HttpBinResponse, HttpBinRequest } from './types';
   baseUrl: 'https://httpbin.org',
 })
 export class PublicApiDataStore {
-  // do simple get with query params
-  @RestApi('/get')
-  doGetWithQueryParams(@QueryParams _queryParams: HttpBinRequest): ApiResponse<HttpBinResponse> {}
-
-  // do simple get with absolute URL
-  // this example will use url defined here
-  // instead of appended it to the baseUrl
+  /**
+   * do get with absolute URL. This example will use
+   * url defined here instead of appended it to the baseUrl
+   */
   @RestApi('https://httpbin.org/get')
   doGetWithAbsoluteUrl(): ApiResponse<HttpBinResponse> {}
 
-  // do simple get with path params
+  /**
+   * do get with query params (as a hash of queryParamKey => queryParamValue)
+   * @param _queryParams
+   */
+  @RestApi('/get')
+  doGetWithQueryParams(@QueryParams _queryParams: HttpBinRequest): ApiResponse<HttpBinResponse> {}
+
+  /**
+   * do get with query params (as a single parameter). This example will construct url as
+   * /get?keyword=<_keyword>&_pageSize=<number>
+   * @param _keyword
+   * @param _pageSize
+   */
+  @RestApi('/get')
+  doGetWithSingleQueryParam(
+    @QueryParam('keyword') _keyword: string = '',
+    @QueryParam('pageSize') _pageSize: number = 100,
+  ): ApiResponse<HttpBinResponse> {}
+
+  /**
+   * do get with a combination of both single query param, and query params hash. In this
+   * example, we will combine the two query params with single query param has higher
+   * precedence than query params hash
+   * @param _query
+   * @param _pageSize
+   */
+  @RestApi('/get')
+  doGetWithQueryParamsCombo(
+    @QueryParams _query: HttpBinRequest,
+    @QueryParam('pageSize') _pageSize: number = 100,
+  ): ApiResponse<HttpBinResponse> {}
+
+  /**
+   * do get with a path param which will replace
+   * `{recordId}` fragment in the URL with value you invoke the method with
+   * @param _recordId value to replace {recordId} URL fragment
+   */
+  @RestApi('/anything/{recordId}')
+  doGetWithPathParams(@PathParam('recordId') _recordId: string): ApiResponse<HttpBinResponse> {}
+
+  /**
+   * do get with path params and query params
+   * @param _messageId value to replace {messageId} URL fragment
+   * @param _queryParams query params
+   */
   @RestApi('/anything/{messageId}')
   doGetWithPathParamsAndQueryParams(
-    @PathParam('messageId') _targetMessageId: string,
+    @PathParam('messageId') _messageId: string,
     @QueryParams _queryParams: HttpBinRequest,
   ): ApiResponse<HttpBinResponse> {}
 
-  // the actual API will return in 10 seconds, but the client
-  // will fail and timeout in 3 seconds
+  /**
+   * do get with a timeout. The REST call will be aborted after
+   * 3 seconds.
+   */
   @RestApi('/delay/10', {
     timeout: 3000,
   })
   doGetWithTimeout(): ApiResponse<HttpBinResponse> {}
 
-  // this API will always return 405 error
+  /**
+   * do get with an Erroneous API. The backend of this API will
+   * always return 405 error
+   */
   @RestApi('/status/405')
   doErroneousAPI(): ApiResponse<HttpBinResponse> {}
 
+  /**
+   * do get with custom encoding from the backend API.
+   * @param _encoding
+   */
   @RestApi('/{encodingToUse}')
   doGetWithResponseEncoding(
     @PathParam('encodingToUse') _encoding: 'brotli' | 'gzip' | 'deflate',
   ): ApiResponse<HttpBinResponse> {}
 
+  /**
+   * do get with XML Response. This method will parse the XML responses into
+   * JSON objects
+   */
   @RestApi('/xml', {
     headers: {
       Accept: 'application/xml',
@@ -55,6 +110,10 @@ export class PublicApiDataStore {
   })
   doGetWithXmlResponse(): ApiResponse<HttpBinResponse> {}
 
+  /**
+   * do get call with Plain Text Response. This method will simply return the
+   * Plain Text response from the back end API.
+   */
   @RestApi('/robots.txt', {
     headers: {
       Accept: 'text/plain',
@@ -62,13 +121,19 @@ export class PublicApiDataStore {
   })
   doGetWithPlainTextResponse(): ApiResponse<string> {}
 
-  // do simple post with JSON request body
+  /**
+   * do post with JSON request body
+   * @param _body
+   */
   @RestApi('/post', {
     method: 'POST',
   })
   doPostWithJsonBody(@RequestBody _body: HttpBinRequest): ApiResponse<HttpBinResponse> {}
 
-  // do simple post with URL encoded form request body
+  /**
+   * do post with URL encoded form request body
+   * @param _body
+   */
   @RestApi('/post', {
     method: 'POST',
     headers: {
@@ -77,7 +142,11 @@ export class PublicApiDataStore {
   })
   doPostWithEncodedFormData(@RequestBody _body: HttpBinRequest): ApiResponse<HttpBinResponse> {}
 
-  // do simple post with formData
+  /**
+   * do post with formData
+   * @param _unitPrice
+   * @param _qty
+   */
   @RestApi('/anything', {
     method: 'POST',
   })
@@ -86,7 +155,10 @@ export class PublicApiDataStore {
     @FormDataBody('quantity') _qty: number,
   ): ApiResponse<HttpBinResponse> {}
 
-  // this example uploads the file via input named `mySms`
+  /**
+   * do post to upload the file via input named `mySms` with formData
+   * @param _mySmsContent
+   */
   @RestApi('/anything', {
     method: 'POST',
   })
@@ -94,7 +166,10 @@ export class PublicApiDataStore {
     @FormDataBody('mySms') _mySmsContent: HttpBinRequest,
   ): ApiResponse<HttpBinResponse> {}
 
-  // this example uploads the file as a single stream
+  /**
+   * do post to upload the file as a single stream
+   * @param _fileToUpload
+   */
   @RestApi('/post', {
     method: 'POST',
   })

--- a/src/__tests__/RetryDataStore.ts
+++ b/src/__tests__/RetryDataStore.ts
@@ -1,12 +1,4 @@
-import {
-  RestClient,
-  RestApi,
-  RequestBody,
-  PathParam,
-  QueryParams,
-  FormDataBody,
-  ApiResponse,
-} from 'restapi-typescript-decorators';
+import { RestClient, RestApi, ApiResponse } from 'restapi-typescript-decorators';
 
 import { HttpBinResponse, HttpBinRequest } from './types';
 

--- a/src/__tests__/TransformationApiDataStore.ts
+++ b/src/__tests__/TransformationApiDataStore.ts
@@ -1,12 +1,4 @@
-import {
-  RestClient,
-  RestApi,
-  RequestBody,
-  PathParam,
-  QueryParams,
-  FormDataBody,
-  ApiResponse,
-} from 'restapi-typescript-decorators';
+import { RestClient, RestApi, RequestBody, ApiResponse } from 'restapi-typescript-decorators';
 
 import { HttpBinResponse } from './types';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,8 +107,20 @@ const _fetchData = (fetchOptions: Request): Promise<Response> => {
   return fetch(url, restFetchOptions);
 };
 
-const _getRequestBody = (instance: any, methodName: string, inputs: any[]) =>
-  inputs[get(instance, ['__decorators', methodName, '@RequestBody'])];
+const _getRequestBody = (instance: any, methodName: string, inputs: any[]) => {
+  const requestBody =
+    inputs[get(instance, ['__decorators', methodName, '@RequestBody-Hash'])] || {};
+
+  const singleQueryParamKeys =
+    get(instance, ['__decorators', methodName, '@RequestBody-SingleValue']) || {};
+  Object.keys(singleQueryParamKeys)
+    .sort()
+    .forEach((queryParamKey) => {
+      requestBody[queryParamKey] = inputs[singleQueryParamKeys[queryParamKey]];
+    });
+
+  return requestBody;
+};
 
 const _getPathParams = (instance: any, methodName: string, inputs: any[]) => {
   const pathParamValues: Record<string, any> = {};
@@ -221,6 +233,10 @@ export const PathParam = (pathParamKey: string) => {
 /**
  * Method Parameter Decorator used to construct query string. The value of this method parameters needs to
  * be a hash (queryStringKey => queryStringValue). Note that this define an entire object for query string.
+ *
+ * When both `@QueryParamProperty` and `@QueryParams` are present in a single method, final
+ * result for query string will be merged with single value `@QueryParamProperty` has
+ * higher precedence than `@QueryParams` hash
  * @param target
  * @param methodName
  * @param paramIdx
@@ -229,11 +245,17 @@ export const QueryParams = (target: any, methodName: string | symbol, paramIdx: 
   set(target, ['__decorators', methodName, '@QueryParams-Hash'], paramIdx);
 };
 
-/* Method Parameter Decorator used to construct query string. This is intended only for a single query param.
+/**
+ * Method Parameter Decorator used to construct query string. This is intended only for a single query param.
+ *
  * If you need to use a hash, please use QueryParams instead.
+ *
+ * When both `@QueryParamProperty` and `@QueryParams` are present in a single method, final
+ * result for query string will be merged with single value `@QueryParamProperty` has
+ * higher precedence than `@QueryParams` hash
  * @param {string} queryParamKey the key for
  */
-export const QueryParam = (queryParamKey: string) => (
+export const QueryParamProperty = (queryParamKey: string) => (
   target: any,
   methodName: string | symbol,
   paramIdx: number,
@@ -241,17 +263,38 @@ export const QueryParam = (queryParamKey: string) => (
   set(target, ['__decorators', methodName, '@QueryParam-SingleValue', queryParamKey], paramIdx);
 };
 
-/** Method Parameter Decorator used to construct the request body. The value of this method
+/**
+ * Method Parameter Decorator used to construct the request body. The value of this method
  * parameters needs to be a hash (requestBodyKey => requestBodyValue). Note that based on the `Content-Type`
  * header, the serialization of the requestBody will change. For example we have built-in
  * body transformation for `application/json`, and `application/x-www-form-urlencoded`, etc...
  *
+ * When both `@RequestProperty` and `@RequestBody` are present in a single method, final
+ * result for requestBody will be merged with single value `@RequestProperty` has
+ * higher precedence than `@RequestBody` hash
  * @param target
  * @param methodName
  * @param paramIdx
  */
 export const RequestBody = (target: any, methodName: string | symbol, paramIdx: number) => {
-  set(target, ['__decorators', methodName, '@RequestBody'], paramIdx);
+  set(target, ['__decorators', methodName, '@RequestBody-Hash'], paramIdx);
+};
+
+/**
+ * Method Parameter Decorator, and it is similar to the @RequestBody, but this
+ * is used to pass a single property into request body.
+ *
+ * When both `@RequestProperty` and `@RequestBody` are present in a single method, final
+ * result for requestBody will be merged with single value `@RequestProperty` has
+ * higher precedence than `@RequestBody` hash
+ * @param requestParamKey
+ */
+export const RequestProperty = (requestParamKey: string) => (
+  target: any,
+  methodName: string | symbol,
+  paramIdx: number,
+) => {
+  set(target, ['__decorators', methodName, '@RequestBody-SingleValue', requestParamKey], paramIdx);
 };
 
 export const FormDataBody = (paramKey: string) => (

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ const _getPathParams = (instance: any, methodName: string, inputs: any[]) => {
   });
 
   // get the path params from the class members
-  const paramKeysFromClassMember = get(instance, ['__decorators', '@PathParam-ClassMember'], {});
+  const paramKeysFromClassMember = get(instance, ['__decorators', '@PathParam-ClassMember']) || {};
 
   Object.keys(paramKeysFromClassMember).forEach((paramKey) => {
     const paramValue = instance[paramKeysFromClassMember[paramKey]];
@@ -136,11 +136,13 @@ const _getPathParams = (instance: any, methodName: string, inputs: any[]) => {
 };
 
 const _getFormDataBody = (instance: any, methodName: string, inputs: any[]) => {
-  const paramKeys = Object.keys(get(instance, ['__decorators', methodName, '@FormDataBody'], {}));
+  const formBodyParamKeys = Object.keys(
+    get(instance, ['__decorators', methodName, '@FormDataBody']) || {},
+  );
 
-  if (paramKeys.length > 0) {
+  if (formBodyParamKeys.length > 0) {
     const myFormData = new FormData();
-    paramKeys.forEach((paramKey) => {
+    formBodyParamKeys.forEach((paramKey) => {
       myFormData.append(
         paramKey,
         inputs[get(instance, ['__decorators', methodName, '@FormDataBody', paramKey])],
@@ -156,8 +158,20 @@ const _getFormDataBody = (instance: any, methodName: string, inputs: any[]) => {
 const _getFileUploadBody = (instance: any, methodName: string, inputs: any[]) =>
   inputs[get(instance, ['__decorators', methodName, '@FileUploadBody'])];
 
-const _getQueryParams = (instance: any, methodName: string, inputs: any[]) =>
-  inputs[get(instance, ['__decorators', methodName, '@QueryParams'])] || {};
+const _getQueryParams = (instance: any, methodName: string, inputs: any[]) => {
+  const queryParams =
+    inputs[get(instance, ['__decorators', methodName, '@QueryParams-Hash'])] || {};
+
+  const singleQueryParamKeys =
+    get(instance, ['__decorators', methodName, '@QueryParam-SingleValue']) || {};
+  Object.keys(singleQueryParamKeys)
+    .sort()
+    .forEach((queryParamKey) => {
+      queryParams[queryParamKey] = inputs[singleQueryParamKeys[queryParamKey]];
+    });
+
+  return queryParams;
+};
 
 const _getCredential = (instance: any) => {
   switch (instance.authType) {
@@ -187,32 +201,44 @@ const _getBase64FromString = (strVal: string) => {
 // decorators
 /**
  * Class Member Decorator or Method Parameter Decorator used to define the path param which used to replace
- * the url fragment `{paramKey}`. This will replace the URL Fragment `{paramKey}` defined in the Class Member
+ * the url fragment `{pathParamKey}`. This will replace the URL Fragment `{pathParamKey}` defined in the Class Member
  * or Method Parameter values.
- * @param {string} paramKey
+ * @param {string} pathParamKey
  */
-export const PathParam = (paramKey: string) => {
+export const PathParam = (pathParamKey: string) => {
   return function(...inputs: any[]) {
     const [target, methodName, paramIdx] = inputs;
     if (paramIdx >= 0) {
       // this decorator is used in a context of a method parameter
-      set(target, ['__decorators', methodName, '@PathParam-ParamIdx', paramKey], paramIdx);
+      set(target, ['__decorators', methodName, '@PathParam-ParamIdx', pathParamKey], paramIdx);
     } else {
       // this decorator is used in a context of a class property
-      set(target, ['__decorators', '@PathParam-ClassMember', paramKey], methodName);
+      set(target, ['__decorators', '@PathParam-ClassMember', pathParamKey], methodName);
     }
   };
 };
 
 /**
  * Method Parameter Decorator used to construct query string. The value of this method parameters needs to
- * be a hash (queryStringKey => queryStringValue)
+ * be a hash (queryStringKey => queryStringValue). Note that this define an entire object for query string.
  * @param target
  * @param methodName
  * @param paramIdx
  */
 export const QueryParams = (target: any, methodName: string | symbol, paramIdx: number) => {
-  set(target, ['__decorators', methodName, '@QueryParams'], paramIdx);
+  set(target, ['__decorators', methodName, '@QueryParams-Hash'], paramIdx);
+};
+
+/* Method Parameter Decorator used to construct query string. This is intended only for a single query param.
+ * If you need to use a hash, please use QueryParams instead.
+ * @param {string} queryParamKey the key for
+ */
+export const QueryParam = (queryParamKey: string) => (
+  target: any,
+  methodName: string | symbol,
+  paramIdx: number,
+) => {
+  set(target, ['__decorators', methodName, '@QueryParam-SingleValue', queryParamKey], paramIdx);
 };
 
 /** Method Parameter Decorator used to construct the request body. The value of this method


### PR DESCRIPTION
- [X] Added Support for single value in `@RequestProperty` and `@QueryParamProperty`


##### Notes on mixture of `@QueryParams` and `@QueryParamProperty`

When both `@QueryParamProperty` and `@QueryParams` are present in a single method, final result for query string will be merged with single value `@QueryParamProperty` has higher precedence than `@QueryParams` hash.

Same for `@RequestProperty` and `@RequestBody`